### PR TITLE
Fix stringToPath conversion

### DIFF
--- a/src/utils/pathUtils.test.ts
+++ b/src/utils/pathUtils.test.ts
@@ -1,0 +1,19 @@
+import { stringToPath, pathToString } from './pathUtils';
+
+describe('pathUtils', () => {
+  describe('stringToPath', () => {
+    it('returns empty array for empty string', () => {
+      expect(stringToPath('')).toEqual([]);
+    });
+
+    it('converts dotted string to number array', () => {
+      expect(stringToPath('1.2.3')).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('pathToString', () => {
+    it('converts number array to dotted string', () => {
+      expect(pathToString([1, 2, 3])).toBe('1.2.3');
+    });
+  });
+});

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -51,7 +51,13 @@ export const pathToString = (path: number[]): string => {
  * @returns Der Pfad als Array von Zahlen
  */
 export const stringToPath = (pathString: string): number[] => {
-  return pathString.split('.').map(Number);
+  if (!pathString) {
+    return [];
+  }
+  return pathString
+    .split('.')
+    .filter(segment => segment !== '')
+    .map(Number);
 };
 
 /**


### PR DESCRIPTION
## Summary
- handle empty strings when converting a path string
- add tests for pathToString and stringToPath utilities

## Testing
- `npm test --silent` *(fails: craco not found)*