### PR TITLE
Modulare Flows: Module authoren (Katalog + Zuordnung)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { generateUUID, transformFlowForExport } from './utils/uuidUtils';
 import styled from 'styled-components';
 import WorkflowNameDialog from './components/WorkflowNameDialog/WorkflowNameDialog';
+import ModuleManagerDialog from './components/ModuleManager/ModuleManagerDialog';
 
 import Navigation from './components/Navigation/Navigation';
 // Wir verwenden jetzt den HybridEditor anstelle dieser Komponenten
@@ -1615,6 +1616,7 @@ const AppContent: React.FC = () => {
   const { state, dispatch } = useEditor();
   const [selectedElementPath, setSelectedElementPath] = useState<number[]>([]);
   const [showWorkflowNameDialog, setShowWorkflowNameDialog] = useState<boolean>(false);
+  const [showModuleManager, setShowModuleManager] = useState<boolean>(false);
   const [groupErrorSnackbar, setGroupErrorSnackbar] = useState<{ open: boolean; message: string }>({ open: false, message: '' });
   // Copy/Export dialog state
   const [copyToPageDialogState, setCopyToPageDialogState] = useState<{ open: boolean; elementPath: number[] }>({ open: false, elementPath: [] });
@@ -2361,6 +2363,7 @@ const AppContent: React.FC = () => {
           onUndo={() => dispatch({ type: 'UNDO' })}
           onRedo={() => dispatch({ type: 'REDO' })}
           onEditWorkflowName={handleEditWorkflowName}
+          onEditModules={() => setShowModuleManager(true)}
           onOpenDocumentation={handleOpenDocumentation}
           workflowName={state.currentFlow?.name || "Workflow"}
         />
@@ -2372,6 +2375,12 @@ const AppContent: React.FC = () => {
           onClose={() => setShowWorkflowNameDialog(false)}
           onSave={handleSaveWorkflowName}
           isFirstTime={false}
+        />
+
+        {/* Modul-Katalog-Manager */}
+        <ModuleManagerDialog
+          open={showModuleManager}
+          onClose={() => setShowModuleManager(false)}
         />
 
         {/* Seitennavigation */}

--- a/src/components/HybridEditor/ElementContextView.tsx
+++ b/src/components/HybridEditor/ElementContextView.tsx
@@ -719,6 +719,15 @@ const DraggableElementCard: React.FC<{
                   backgroundColor: 'rgba(0, 0, 0, 0.05)'
                 }}
               />
+              {(element.element as any).module_id && (
+                <Chip
+                  size="small"
+                  color="info"
+                  variant="outlined"
+                  label={`Modul: ${(element.element as any).module_id}`}
+                  sx={{ height: '20px', fontSize: '0.6rem' }}
+                />
+              )}
             </Box>
 
             {/* Bedingte Anzeige von ID-Feldern basierend auf dem Elementtyp */}

--- a/src/components/HybridEditor/EnhancedPropertyEditor.tsx
+++ b/src/components/HybridEditor/EnhancedPropertyEditor.tsx
@@ -6,7 +6,12 @@ import {
   Typography,
   TextField,
   Tabs,
-  Tab
+  Tab,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  FormHelperText
 } from '@mui/material';
 
 import VisibilityIcon from '@mui/icons-material/Visibility';
@@ -18,7 +23,7 @@ import { PatternLibraryElement } from '../../models/listingFlow';
 import { VisibilityConditionEditor } from '../PropertyEditor/editors/VisibilityConditionEditor';
 import StructureNavigator from './StructureNavigator';
 import EnhancedElementEditorFactory from './EnhancedElementEditorFactory';
-import { getContainerType } from '../../context/EditorContext';
+import { getContainerType, useEditor } from '../../context/EditorContext';
 
 const PropertyEditorContainer = styled(Paper)`
   width: 100%;
@@ -96,6 +101,8 @@ const EnhancedPropertyEditor: React.FC<EnhancedPropertyEditorProps> = ({
   selectedElementPath
 }) => {
   const [activeTab, setActiveTab] = useState<string>('general');
+  const { state } = useEditor();
+  const modules = state.currentFlow?.modules ?? [];
 
   // Handler für Tab-Wechsel
   const handleTabChange = (_event: React.SyntheticEvent, newValue: string) => {
@@ -123,6 +130,15 @@ const EnhancedPropertyEditor: React.FC<EnhancedPropertyEditorProps> = ({
 
   // Die Handler für Auswahlfelder und Schalter werden nicht mehr benötigt,
   // da diese Funktionalität jetzt in den spezialisierten Editor-Komponenten implementiert ist.
+
+  // Handler für die Modul-Zuordnung (module_id)
+  const handleModuleIdChange = (value: string) => {
+    if (!element) return;
+    onUpdate({
+      ...element,
+      element: { ...element.element, module_id: value || undefined } as any,
+    });
+  };
 
   // Handler für Änderungen an der Visibility Condition
   const handleVisibilityConditionChange = (condition: any) => {
@@ -173,6 +189,33 @@ const EnhancedPropertyEditor: React.FC<EnhancedPropertyEditorProps> = ({
                 variant="outlined"
                 size="small"
               />
+            </FormField>
+          )}
+
+          {/* Modul-Zuordnung (nur wenn der Flow Module deklariert) */}
+          {modules.length > 0 && (
+            <FormField>
+              <FormControl fullWidth size="small">
+                <InputLabel id="module-id-select-label">Modul-Zuordnung</InputLabel>
+                <Select
+                  labelId="module-id-select-label"
+                  label="Modul-Zuordnung"
+                  value={(element.element as any).module_id || ''}
+                  onChange={(e) => handleModuleIdChange(e.target.value as string)}
+                >
+                  <MenuItem value="">
+                    <em>— Kein Modul —</em>
+                  </MenuItem>
+                  {modules.map((module) => (
+                    <MenuItem key={module.id} value={module.id}>
+                      {module.name?.de || module.name?.en || module.id}
+                    </MenuItem>
+                  ))}
+                </Select>
+                <FormHelperText>
+                  Element nur sichtbar, wenn das zugeordnete Modul aktiv ist.
+                </FormHelperText>
+              </FormControl>
             </FormField>
           )}
 

--- a/src/components/ModuleManager/ModuleManagerDialog.tsx
+++ b/src/components/ModuleManager/ModuleManagerDialog.tsx
@@ -1,0 +1,325 @@
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  Typography,
+  Card,
+  CardContent,
+  IconButton,
+  Chip,
+  Switch,
+  FormControlLabel,
+  TextField,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  Divider,
+  Stack,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AddIcon from '@mui/icons-material/Add';
+import Icon from '@mdi/react';
+import { getIconPath } from '../../utils/mdiIcons';
+import { TabbedTranslatableFields } from '../PropertyEditor/common/TabbedTranslatableFields';
+import IconField from '../PropertyEditor/common/IconField';
+import { useEditor } from '../../context/EditorContext';
+import { Module } from '../../models/listingFlow';
+
+interface ModuleManagerDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SLUG_PATTERN = /^[a-z0-9_]+$/;
+
+const emptyModule = (): Module => ({
+  id: '',
+  name: { de: '', en: '' },
+  description: { de: '', en: '' },
+  icon: '',
+  default_active: false,
+  delivery: 'INLINE',
+});
+
+/**
+ * Verwaltet den Modul-Katalog des aktuellen Flows (ListingFlow.modules):
+ * Module anlegen, bearbeiten und löschen. Module sind optional pro Projekt aktivierbar
+ * (Aktivierungsfeld `module_<id>_active`); mit `module_id` getaggte Seiten/Elemente
+ * werden nur sichtbar, wenn ihr Modul aktiv ist.
+ */
+const ModuleManagerDialog: React.FC<ModuleManagerDialogProps> = ({ open, onClose }) => {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
+  const { state, dispatch } = useEditor();
+
+  const modules = state.currentFlow?.modules ?? [];
+
+  // Editor-Sub-Dialog (Anlegen/Bearbeiten)
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editModule, setEditModule] = useState<Module>(emptyModule());
+  const [languageTab, setLanguageTab] = useState(0);
+
+  // Lösch-Bestätigung
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const handleOpenAdd = () => {
+    setEditingId(null);
+    setEditModule(emptyModule());
+    setLanguageTab(0);
+    setEditorOpen(true);
+  };
+
+  const handleOpenEdit = (module: Module) => {
+    setEditingId(module.id);
+    setEditModule({ ...module });
+    setLanguageTab(0);
+    setEditorOpen(true);
+  };
+
+  const idError = (() => {
+    const id = editModule.id.trim();
+    if (!id) return 'ID erforderlich';
+    if (!SLUG_PATTERN.test(id)) return 'Nur Kleinbuchstaben, Ziffern und Unterstrich';
+    if (modules.some(m => m.id === id && m.id !== editingId)) return 'ID bereits vergeben';
+    return null;
+  })();
+
+  const handleSaveModule = () => {
+    if (idError) return;
+    const moduleToSave: Module = { ...editModule, id: editModule.id.trim() };
+    if (editingId === null) {
+      dispatch({ type: 'ADD_MODULE', module: moduleToSave });
+    } else {
+      dispatch({ type: 'UPDATE_MODULE', moduleId: editingId, updates: moduleToSave });
+    }
+    setEditorOpen(false);
+  };
+
+  const handleConfirmDelete = () => {
+    if (confirmDeleteId) {
+      dispatch({ type: 'REMOVE_MODULE', moduleId: confirmDeleteId });
+    }
+    setConfirmDeleteId(null);
+  };
+
+  const renderModuleIcon = (iconName?: string) => {
+    if (!iconName || !iconName.startsWith('mdi')) return null;
+    const path = getIconPath(iconName);
+    return path ? <Icon path={path} size={1} /> : null;
+  };
+
+  const isCatalog = editModule.delivery === 'CATALOG';
+
+  return (
+    <>
+      <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth fullScreen={fullScreen}>
+        <DialogTitle>Module verwalten</DialogTitle>
+        <DialogContent sx={{ p: { xs: 2, sm: 3 } }}>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Module sind optionale, pro Projekt aktivierbare Bausteine. Seiten und Elemente werden
+            später per Modul-Zuordnung einem Modul zugewiesen und sind nur sichtbar, wenn das Projekt
+            das Modul aktiviert hat.
+          </Typography>
+
+          {modules.length === 0 ? (
+            <Box
+              sx={{
+                py: 4,
+                textAlign: 'center',
+                color: 'text.secondary',
+                border: '1px dashed',
+                borderColor: 'divider',
+                borderRadius: 1,
+              }}
+            >
+              <Typography variant="body2">Noch keine Module angelegt.</Typography>
+            </Box>
+          ) : (
+            <Stack spacing={1}>
+              {modules.map(module => (
+                <Card key={module.id} variant="outlined">
+                  <CardContent sx={{ '&:last-child': { pb: 2 } }}>
+                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 1 }}>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+                        {renderModuleIcon(module.icon)}
+                        <Box sx={{ minWidth: 0 }}>
+                          <Typography variant="subtitle2" noWrap>
+                            {module.name?.de || module.id}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary" noWrap>
+                            {module.id}
+                          </Typography>
+                        </Box>
+                      </Box>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexShrink: 0 }}>
+                        <Chip
+                          size="small"
+                          label={module.delivery || 'INLINE'}
+                          color={module.delivery === 'CATALOG' ? 'info' : 'default'}
+                          variant="outlined"
+                        />
+                        {module.default_active && (
+                          <Chip size="small" label="Standard aktiv" color="success" variant="outlined" />
+                        )}
+                        <IconButton size="small" onClick={() => handleOpenEdit(module)} aria-label="Bearbeiten">
+                          <EditIcon fontSize="small" />
+                        </IconButton>
+                        <IconButton
+                          size="small"
+                          color="error"
+                          onClick={() => setConfirmDeleteId(module.id)}
+                          aria-label="Löschen"
+                        >
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      </Box>
+                    </Box>
+                  </CardContent>
+                </Card>
+              ))}
+            </Stack>
+          )}
+
+          <Button startIcon={<AddIcon />} onClick={handleOpenAdd} sx={{ mt: 2 }}>
+            Modul hinzufügen
+          </Button>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>Schließen</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Sub-Dialog: Modul anlegen / bearbeiten */}
+      <Dialog
+        open={editorOpen}
+        onClose={() => setEditorOpen(false)}
+        maxWidth="sm"
+        fullWidth
+        fullScreen={fullScreen}
+      >
+        <DialogTitle>{editingId === null ? 'Neues Modul' : 'Modul bearbeiten'}</DialogTitle>
+        <DialogContent sx={{ p: { xs: 2, sm: 3 } }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+            <TextField
+              label="Modul-ID"
+              size="small"
+              fullWidth
+              value={editModule.id}
+              onChange={e => setEditModule({ ...editModule, id: e.target.value })}
+              error={!!idError}
+              helperText={idError || `Aktivierungsfeld: module_${editModule.id || '<id>'}_active`}
+            />
+            {editingId !== null && (
+              <Typography variant="caption" color="warning.main">
+                Achtung: Die ID ist der Schlüssel des Moduls. Beim Ändern werden bestehende
+                Zuordnungen (module_id) automatisch mit-migriert.
+              </Typography>
+            )}
+
+            <TabbedTranslatableFields
+              fields={[
+                {
+                  id: 'name',
+                  label: 'Name',
+                  value: editModule.name,
+                  onChange: value => setEditModule({ ...editModule, name: value }),
+                },
+                {
+                  id: 'description',
+                  label: 'Beschreibung',
+                  value: editModule.description,
+                  onChange: value => setEditModule({ ...editModule, description: value }),
+                  multiline: true,
+                  rows: 2,
+                },
+              ]}
+              languageTab={languageTab}
+              onLanguageTabChange={setLanguageTab}
+            />
+
+            <IconField
+              value={editModule.icon || ''}
+              onChange={value => setEditModule({ ...editModule, icon: value })}
+              label="Icon"
+              fullWidth
+            />
+
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={!!editModule.default_active}
+                  onChange={e => setEditModule({ ...editModule, default_active: e.target.checked })}
+                />
+              }
+              label="Bei Projektanlage vorausgewählt"
+            />
+
+            <Divider />
+
+            <FormControl size="small" fullWidth>
+              <InputLabel id="module-delivery-label">Auslieferung</InputLabel>
+              <Select
+                labelId="module-delivery-label"
+                label="Auslieferung"
+                value={editModule.delivery || 'INLINE'}
+                onChange={e =>
+                  setEditModule({ ...editModule, delivery: e.target.value as 'INLINE' | 'CATALOG' })
+                }
+              >
+                <MenuItem value="INLINE">INLINE (im Flow enthalten)</MenuItem>
+                <MenuItem value="CATALOG">CATALOG (separat nachladbar)</MenuItem>
+              </Select>
+            </FormControl>
+
+            {isCatalog && (
+              <TextField
+                label="Version"
+                size="small"
+                fullWidth
+                value={editModule.version || ''}
+                onChange={e => setEditModule({ ...editModule, version: e.target.value })}
+                placeholder="z. B. 1.0.0"
+                helperText="Semver-artige Version des CATALOG-Modul-Artefakts"
+              />
+            )}
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditorOpen(false)}>Abbrechen</Button>
+          <Button onClick={handleSaveModule} variant="contained" disabled={!!idError}>
+            Speichern
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Lösch-Bestätigung */}
+      <Dialog open={confirmDeleteId !== null} onClose={() => setConfirmDeleteId(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Modul löschen?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">
+            Das Modul wird aus dem Katalog entfernt. Bestehende Zuordnungen (module_id) an Seiten und
+            Elementen werden dabei gelöst — die betroffenen Inhalte bleiben erhalten und sind wieder
+            modul-unabhängig sichtbar.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmDeleteId(null)}>Abbrechen</Button>
+          <Button onClick={handleConfirmDelete} variant="contained" color="error">
+            Löschen
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default ModuleManagerDialog;

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -8,6 +8,7 @@ import {
   Undo as UndoIcon,
   Redo as RedoIcon,
   Edit as EditIcon,
+  Extension as ModulesIcon,
   HelpOutline as HelpIcon
 } from '@mui/icons-material';
 
@@ -20,6 +21,7 @@ interface NavigationProps {
   onUndo: () => void;
   onRedo: () => void;
   onEditWorkflowName: () => void;
+  onEditModules: () => void;
   onOpenDocumentation?: () => void;
   workflowName: string;
 }
@@ -56,6 +58,7 @@ const Navigation: React.FC<NavigationProps> = ({
   onUndo,
   onRedo,
   onEditWorkflowName,
+  onEditModules,
   onOpenDocumentation,
   workflowName
 }) => {
@@ -119,6 +122,15 @@ const Navigation: React.FC<NavigationProps> = ({
               }}
             >
               {workflowName || "Workflow"}
+            </Button>
+          </Tooltip>
+          <Tooltip title="Module verwalten">
+            <Button
+              variant="outlined"
+              startIcon={<ModulesIcon />}
+              onClick={onEditModules}
+            >
+              Module
             </Button>
           </Tooltip>
         </LeftActions>

--- a/src/components/PageNavigator/EditPageDialog.tsx
+++ b/src/components/PageNavigator/EditPageDialog.tsx
@@ -62,6 +62,7 @@ const EditPageDialog: React.FC<EditPageDialogProps> = ({
   const [titleEn, setTitleEn] = useState(page.title?.en || '');
   const [icon, setIcon] = useState(page.icon || '');
   const [layout, setLayout] = useState(page.layout || (isEditPage ? '2_COL_RIGHT_FILL' : '2_COL_RIGHT_WIDER'));
+  const [moduleId, setModuleId] = useState(page.module_id || '');
   const [iconSelectorOpen, setIconSelectorOpen] = useState(false);
   const [visibilityCondition, setVisibilityCondition] = useState<VisibilityCondition | undefined>(page.visibility_condition);
   const [builderCondition, setBuilderCondition] = useState<BuilderCondition | undefined>(toBuilderFormat(page.visibility_condition));
@@ -253,6 +254,7 @@ const EditPageDialog: React.FC<EditPageDialogProps> = ({
       },
       icon: icon,
       layout: layout,
+      module_id: moduleId || undefined,
       visibility_condition: visibilityCondition
     };
 
@@ -481,7 +483,31 @@ const EditPageDialog: React.FC<EditPageDialogProps> = ({
               </FormHelperText>
             </FormControl>
 
-
+            {/* Modul-Zuordnung (nur wenn der Flow Module deklariert) */}
+            {(state.currentFlow?.modules?.length ?? 0) > 0 && (
+              <FormControl fullWidth margin="dense" sx={{ mb: 3 }}>
+                <InputLabel id="page-module-select-label">Modul-Zuordnung</InputLabel>
+                <Select
+                  labelId="page-module-select-label"
+                  id="page-module-select"
+                  value={moduleId}
+                  label="Modul-Zuordnung"
+                  onChange={(e) => setModuleId(e.target.value)}
+                >
+                  <MenuItem value="">
+                    <em>— Kein Modul —</em>
+                  </MenuItem>
+                  {(state.currentFlow?.modules ?? []).map((module) => (
+                    <MenuItem key={module.id} value={module.id}>
+                      {module.name?.de || module.name?.en || module.id}
+                    </MenuItem>
+                  ))}
+                </Select>
+                <FormHelperText>
+                  Seite nur sichtbar, wenn das zugeordnete Modul aktiv ist.
+                </FormHelperText>
+              </FormControl>
+            )}
 
             {/* Icon-Auswahl */}
             <Typography variant="subtitle1" gutterBottom>

--- a/src/context/EditorContext.test.tsx
+++ b/src/context/EditorContext.test.tsx
@@ -342,6 +342,61 @@ describe('EditorContext - Modul-Katalog', () => {
   });
 });
 
+// Tests für Page-Tagging (module_id) via UPDATE_PAGE inkl. View-Page-Sync
+const PageModuleTestComponent = () => {
+  const { state, dispatch } = useContext(EditorContext)!;
+
+  const flow = {
+    id: 'f',
+    'url-key': 'f',
+    name: 'F',
+    title: { de: 'F', en: 'F' },
+    icon: 'mdiFileOutline',
+    pages_edit: [{ id: 'edit-1', pattern_type: 'CustomUIElement', title: { de: 'Edit' }, elements: [] }],
+    pages_view: [{ id: 'view-1', pattern_type: 'CustomUIElement', title: { de: 'View' }, elements: [] }],
+  };
+
+  const editPage = state.currentFlow?.pages_edit.find(p => p.id === 'edit-1');
+  const viewPage = state.currentFlow?.pages_view.find(p => p.id === 'view-1');
+
+  return (
+    <div>
+      <div data-testid="edit-module-id">{editPage?.module_id ?? 'none'}</div>
+      <div data-testid="view-module-id">{viewPage?.module_id ?? 'none'}</div>
+      <button data-testid="set-flow-btn" onClick={() => dispatch({ type: 'SET_FLOW', flow })}>Set</button>
+      <button
+        data-testid="tag-page-btn"
+        onClick={() =>
+          dispatch({
+            type: 'UPDATE_PAGE',
+            page: { id: 'edit-1', pattern_type: 'CustomUIElement', title: { de: 'Edit' }, elements: [], module_id: 'heizlast' },
+          })
+        }
+      >
+        Tag
+      </button>
+    </div>
+  );
+};
+
+describe('EditorContext - Page-Tagging (module_id)', () => {
+  test('UPDATE_PAGE setzt module_id auf Edit-Seite und synchronisiert es auf die View-Seite', () => {
+    render(
+      <EditorProvider>
+        <PageModuleTestComponent />
+      </EditorProvider>
+    );
+
+    fireEvent.click(screen.getByTestId('set-flow-btn'));
+    expect(screen.getByTestId('edit-module-id')).toHaveTextContent('none');
+    expect(screen.getByTestId('view-module-id')).toHaveTextContent('none');
+
+    fireEvent.click(screen.getByTestId('tag-page-btn'));
+    expect(screen.getByTestId('edit-module-id')).toHaveTextContent('heizlast');
+    expect(screen.getByTestId('view-module-id')).toHaveTextContent('heizlast');
+  });
+});
+
 // Tests für getElementByPath
 describe('getElementByPath', () => {
   const deepTextElement: TextUIElement = {

--- a/src/context/EditorContext.test.tsx
+++ b/src/context/EditorContext.test.tsx
@@ -224,6 +224,124 @@ describe('EditorContext', () => {
   });
 });
 
+// Tests für den Modul-Katalog (Modulare Flows, Phase 2)
+const ModuleTestComponent = () => {
+  const { state, dispatch } = useContext(EditorContext)!;
+
+  const taggedElement = {
+    pattern_type: 'TextUIElement',
+    type: 'PARAGRAPH',
+    text: { de: 'Modul-Element' },
+    required: false,
+    module_id: 'heizlast',
+  } as any;
+
+  const moduleFlow = {
+    id: 'mod-flow',
+    'url-key': 'mod',
+    name: 'Modul Flow',
+    title: { de: 'Modul Flow', en: 'Module Flow' },
+    icon: 'mdiFileOutline',
+    pages_edit: [
+      {
+        id: 'page-1',
+        pattern_type: 'Page',
+        title: { de: 'Seite 1', en: 'Page 1' },
+        module_id: 'heizlast',
+        elements: [{ element: taggedElement }],
+      },
+    ],
+    pages_view: [],
+  };
+
+  const modules = state.currentFlow?.modules ?? [];
+  const page = state.currentFlow?.pages_edit[0];
+  const firstElement = page?.elements[0]?.element as any;
+
+  return (
+    <div>
+      <div data-testid="module-count">{modules.length}</div>
+      <div data-testid="first-module-default-active">{String(modules[0]?.default_active ?? 'none')}</div>
+      <div data-testid="page-module-id">{page?.module_id ?? 'none'}</div>
+      <div data-testid="element-module-id">{firstElement?.module_id ?? 'none'}</div>
+      <div data-testid="can-undo">{state.undoStack.length > 0 ? 'can-undo' : 'cannot-undo'}</div>
+
+      <button data-testid="set-flow-btn" onClick={() => dispatch({ type: 'SET_FLOW', flow: moduleFlow })}>Set</button>
+      <button
+        data-testid="add-module-btn"
+        onClick={() =>
+          dispatch({
+            type: 'ADD_MODULE',
+            module: { id: 'heizlast', name: { de: 'Heizlast' }, description: { de: '' }, default_active: false, delivery: 'INLINE' },
+          })
+        }
+      >
+        Add
+      </button>
+      <button
+        data-testid="update-module-btn"
+        onClick={() => dispatch({ type: 'UPDATE_MODULE', moduleId: 'heizlast', updates: { default_active: true } })}
+      >
+        Update
+      </button>
+      <button data-testid="remove-module-btn" onClick={() => dispatch({ type: 'REMOVE_MODULE', moduleId: 'heizlast' })}>
+        Remove
+      </button>
+      <button data-testid="undo-btn" onClick={() => dispatch({ type: 'UNDO' })}>Undo</button>
+    </div>
+  );
+};
+
+describe('EditorContext - Modul-Katalog', () => {
+  const renderModuleTest = () =>
+    render(
+      <EditorProvider>
+        <ModuleTestComponent />
+      </EditorProvider>
+    );
+
+  test('ADD_MODULE fügt ein Modul zum Katalog hinzu', () => {
+    renderModuleTest();
+    fireEvent.click(screen.getByTestId('set-flow-btn'));
+    expect(screen.getByTestId('module-count')).toHaveTextContent('0');
+    fireEvent.click(screen.getByTestId('add-module-btn'));
+    expect(screen.getByTestId('module-count')).toHaveTextContent('1');
+  });
+
+  test('UPDATE_MODULE ändert ein Feld des Moduls', () => {
+    renderModuleTest();
+    fireEvent.click(screen.getByTestId('set-flow-btn'));
+    fireEvent.click(screen.getByTestId('add-module-btn'));
+    expect(screen.getByTestId('first-module-default-active')).toHaveTextContent('false');
+    fireEvent.click(screen.getByTestId('update-module-btn'));
+    expect(screen.getByTestId('first-module-default-active')).toHaveTextContent('true');
+  });
+
+  test('REMOVE_MODULE entfernt das Modul und bereinigt referenzierende module_id (Page + Element)', () => {
+    renderModuleTest();
+    fireEvent.click(screen.getByTestId('set-flow-btn'));
+    fireEvent.click(screen.getByTestId('add-module-btn'));
+    // Vorbedingung: Page und Element sind getaggt
+    expect(screen.getByTestId('page-module-id')).toHaveTextContent('heizlast');
+    expect(screen.getByTestId('element-module-id')).toHaveTextContent('heizlast');
+
+    fireEvent.click(screen.getByTestId('remove-module-btn'));
+    expect(screen.getByTestId('module-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('page-module-id')).toHaveTextContent('none');
+    expect(screen.getByTestId('element-module-id')).toHaveTextContent('none');
+  });
+
+  test('Undo nach ADD_MODULE stellt den Vorzustand wieder her', () => {
+    renderModuleTest();
+    fireEvent.click(screen.getByTestId('set-flow-btn'));
+    fireEvent.click(screen.getByTestId('add-module-btn'));
+    expect(screen.getByTestId('module-count')).toHaveTextContent('1');
+    expect(screen.getByTestId('can-undo')).toHaveTextContent('can-undo');
+    fireEvent.click(screen.getByTestId('undo-btn'));
+    expect(screen.getByTestId('module-count')).toHaveTextContent('0');
+  });
+});
+
 // Tests für getElementByPath
 describe('getElementByPath', () => {
   const deepTextElement: TextUIElement = {

--- a/src/context/EditorContext.tsx
+++ b/src/context/EditorContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useReducer, ReactNode } from 'react';
 import { v4 as uuidv4 } from 'uuid';
-import { ListingFlow, Page, PatternLibraryElement } from '../models/listingFlow';
+import { ListingFlow, Module, Page, PatternLibraryElement } from '../models/listingFlow';
 import { ChipGroupUIElement, GroupUIElement } from '../models/uiElements';
 import { ensureUUIDs } from '../utils/uuidUtils';
 import { logger } from '../utils/logger';
@@ -42,6 +42,9 @@ type Action =
   | { type: 'UNGROUP'; payload: { path: number[]; pageId: string } } // Gruppierung auflösen
   | { type: 'IMPORT_PAGES'; payload: { editPages: Page[]; viewPages: Page[] } } // Seiten aus externer Datei importieren
   | { type: 'COPY_ELEMENT_TO_PAGE'; payload: { targetPageId: string; clonedElement: PatternLibraryElement; position: 'top' | 'bottom' } } // Element auf andere Seite kopieren
+  | { type: 'ADD_MODULE'; module: Module } // Modul zum Katalog hinzufügen
+  | { type: 'UPDATE_MODULE'; moduleId: string; updates: Partial<Module> } // Modul bearbeiten (bei id-Änderung werden Referenzen mit-migriert)
+  | { type: 'REMOVE_MODULE'; moduleId: string } // Modul entfernen und referenzierende module_id bereinigen
   | { type: 'UNDO' }
   | { type: 'REDO' };
 
@@ -637,6 +640,87 @@ const removeElementAtPath = (
   });
 };
 
+/**
+ * Wendet eine Transformation auf das `module_id` eines Elements und rekursiv aller
+ * verschachtelten Elemente an (Group/Array/Custom.elements, Custom/Page.sub_flows[].elements,
+ * ChipGroup.chips). Gibt `undefined` zurück = `module_id` wird entfernt.
+ */
+const transformElementModuleId = (
+  ple: PatternLibraryElement,
+  fn: (moduleId: string | undefined) => string | undefined
+): PatternLibraryElement => {
+  const el: any = { ...ple.element };
+
+  const newModuleId = fn(el.module_id);
+  if (newModuleId === undefined) {
+    delete el.module_id;
+  } else {
+    el.module_id = newModuleId;
+  }
+
+  if (Array.isArray(el.elements)) {
+    el.elements = el.elements.map((child: PatternLibraryElement) => transformElementModuleId(child, fn));
+  }
+
+  if (Array.isArray(el.sub_flows)) {
+    el.sub_flows = el.sub_flows.map((sf: any) => ({
+      ...sf,
+      elements: Array.isArray(sf.elements)
+        ? sf.elements.map((child: PatternLibraryElement) => transformElementModuleId(child, fn))
+        : sf.elements,
+    }));
+  }
+
+  if (Array.isArray(el.chips)) {
+    el.chips = el.chips.map((chip: any) => {
+      const c = { ...chip };
+      const nm = fn(c.module_id);
+      if (nm === undefined) {
+        delete c.module_id;
+      } else {
+        c.module_id = nm;
+      }
+      return c;
+    });
+  }
+
+  return { element: el };
+};
+
+/**
+ * Wendet eine module_id-Transformation auf eine Seitenliste an: auf die Seite selbst
+ * und rekursiv auf alle (verschachtelten) Elemente und sub_flows. Immutable.
+ */
+const transformPagesModuleId = (
+  pages: Page[],
+  fn: (moduleId: string | undefined) => string | undefined
+): Page[] =>
+  pages.map(page => {
+    const p: any = { ...page };
+
+    const newModuleId = fn(p.module_id);
+    if (newModuleId === undefined) {
+      delete p.module_id;
+    } else {
+      p.module_id = newModuleId;
+    }
+
+    if (Array.isArray(p.elements)) {
+      p.elements = p.elements.map((child: PatternLibraryElement) => transformElementModuleId(child, fn));
+    }
+
+    if (Array.isArray(p.sub_flows)) {
+      p.sub_flows = p.sub_flows.map((sf: any) => ({
+        ...sf,
+        elements: Array.isArray(sf.elements)
+          ? sf.elements.map((child: PatternLibraryElement) => transformElementModuleId(child, fn))
+          : sf.elements,
+      }));
+    }
+
+    return p as Page;
+  });
+
 function editorReducer(state: EditorState, action: Action): EditorState {
   switch (action.type) {
     case 'SET_FLOW':
@@ -665,6 +749,67 @@ function editorReducer(state: EditorState, action: Action): EditorState {
         redoStack: [],
         isDirty: true,
       };
+
+    case 'ADD_MODULE': {
+      if (!state.currentFlow) return state;
+      const newFlow: ListingFlow = {
+        ...state.currentFlow,
+        modules: [...(state.currentFlow.modules ?? []), action.module],
+      };
+      return {
+        ...state,
+        undoStack: [...state.undoStack, state.currentFlow],
+        currentFlow: newFlow,
+        redoStack: [],
+        isDirty: true,
+      };
+    }
+
+    case 'UPDATE_MODULE': {
+      if (!state.currentFlow) return state;
+      const { moduleId, updates } = action;
+      const updatedModules = (state.currentFlow.modules ?? []).map(m =>
+        m.id === moduleId ? { ...m, ...updates } : m
+      );
+      let newFlow: ListingFlow = { ...state.currentFlow, modules: updatedModules };
+
+      // Bei id-Änderung referenzierende module_id über alle Seiten/Elemente mit-migrieren
+      if (updates.id && updates.id !== moduleId) {
+        const rename = (mid: string | undefined) => (mid === moduleId ? updates.id! : mid);
+        newFlow = {
+          ...newFlow,
+          pages_edit: transformPagesModuleId(newFlow.pages_edit, rename),
+          pages_view: transformPagesModuleId(newFlow.pages_view, rename),
+        };
+      }
+
+      return {
+        ...state,
+        undoStack: [...state.undoStack, state.currentFlow],
+        currentFlow: newFlow,
+        redoStack: [],
+        isDirty: true,
+      };
+    }
+
+    case 'REMOVE_MODULE': {
+      if (!state.currentFlow) return state;
+      const { moduleId } = action;
+      const clear = (mid: string | undefined) => (mid === moduleId ? undefined : mid);
+      const newFlow: ListingFlow = {
+        ...state.currentFlow,
+        modules: (state.currentFlow.modules ?? []).filter(m => m.id !== moduleId),
+        pages_edit: transformPagesModuleId(state.currentFlow.pages_edit, clear),
+        pages_view: transformPagesModuleId(state.currentFlow.pages_view, clear),
+      };
+      return {
+        ...state,
+        undoStack: [...state.undoStack, state.currentFlow],
+        currentFlow: newFlow,
+        redoStack: [],
+        isDirty: true,
+      };
+    }
 
     case 'SELECT_ELEMENT':
       return {

--- a/src/context/EditorContext.tsx
+++ b/src/context/EditorContext.tsx
@@ -1203,6 +1203,7 @@ function editorReducer(state: EditorState, action: Action): EditorState {
               short_title: action.page.short_title,
               icon: action.page.icon,
               // layout wird NICHT übernommen – View-Pages haben ihr eigenes Layout (2_COL_RIGHT_WIDER)
+              module_id: action.page.module_id,
               visibility_condition: action.page.visibility_condition
             };
           }

--- a/src/models/listingFlow.ts
+++ b/src/models/listingFlow.ts
@@ -12,6 +12,34 @@ export interface ListingFlow {
   icon: string;
   pages_edit: Page[];
   pages_view: Page[];
+  // Optionaler Modul-Katalog dieses Flows. Fehlt er / leer = keine Module (heutiges Verhalten).
+  // Aktiviert wird ein Modul über das Boolean-Feld `module_<id>_active`; mit `module_id`
+  // getaggte Seiten/Elemente sind nur sichtbar, wenn ihr Modul aktiv ist.
+  modules?: Module[];
+  // Semver-artige Version des Flow-Artefakts. Relevant für CATALOG-Modul-Artefakte
+  // (eigenständige flow-förmige JSONs), damit veraltete Caches erkannt werden.
+  version?: string;
+}
+
+// Ein optional pro Projekt aktivierbares Modul eines Flows (z. B. ISFP, Heizlast,
+// Hydraulischer Abgleich). Bündelt zusätzliche Seiten/Felder, die ein Projekt bei Bedarf
+// — auch nachträglich — aktivieren kann.
+export interface Module {
+  // Stabile id; Aktivierungs-Feld eines Projekts heißt `module_<id>_active`.
+  id: string;
+  // Anzeigename des Moduls (übersetzt).
+  name: TranslatableString;
+  // Kurzbeschreibung für den Auswahl-/Katalog-Dialog (übersetzt).
+  description: TranslatableString;
+  // mdi-Icon-Name für die Modul-Darstellung.
+  icon?: string;
+  // Wenn true, ist das Modul bei der Projektanlage vorausgewählt.
+  default_active?: boolean;
+  // Auslieferungsart: INLINE (im Flow enthalten, Default) oder CATALOG
+  // (separates Artefakt, nachladbar und offline-cachebar).
+  delivery?: 'INLINE' | 'CATALOG';
+  // Semver-artige Version des Modul-Artefakts. Nur für CATALOG-Module gesetzt.
+  version?: string;
 }
 
 export interface Page {
@@ -29,6 +57,10 @@ export interface Page {
   sub_flows?: SubFlow[];
   related_custom_ui_element_id?: string;
   type?: string;
+  // Markiert diese Seite als Teil des Moduls mit dieser id (→ ListingFlow.modules[].id).
+  // Die Seite ist dann nur sichtbar, wenn das Modul aktiv ist (`module_<id>_active === true`).
+  // null/absent = gehört zu keinem Modul (immer sichtbar).
+  module_id?: string;
 }
 
 export interface SubFlow {
@@ -52,6 +84,11 @@ export interface UIElementBase {
   tree_level?: number;
   display_position?: 'LEFT' | 'RIGHT';
   display_variant?: 'DEFAULT' | 'FULLSCREEN';
+  // Markiert dieses Element (und seinen Teilbaum) als Teil des Moduls mit dieser id
+  // (→ ListingFlow.modules[].id). Sichtbarkeit wird automatisch an die Modul-Aktivierung
+  // (Feld `module_<id>_active`) gekoppelt. null/absent = modul-unabhängig (immer sichtbar).
+  // Gilt via Vererbung für alle UIElement-Typen inkl. GroupUIElement.
+  module_id?: string;
 }
 
 export interface UIElementEdit extends UIElementBase {

--- a/src/utils/uuidUtils.test.ts
+++ b/src/utils/uuidUtils.test.ts
@@ -405,4 +405,63 @@ describe('uuidUtils', () => {
       expect(mockedUuidv4).toHaveBeenCalled();
     });
   });
+
+  describe('Modulare Flows: modules & module_id', () => {
+    it('erhält modules, flow-version und module_id (Page + Element) beim Export-Round-Trip und strippt nur uuid', () => {
+      const element: StringUIElement = {
+        pattern_type: 'StringUIElement',
+        type: 'TEXT',
+        required: false,
+        field_id: { field_name: 'heizlast_result' },
+        uuid: 'el-uuid',
+        module_id: 'heizlast',
+      };
+
+      const page: Page = {
+        pattern_type: 'Page',
+        id: 'page-heizlast',
+        module_id: 'heizlast',
+        elements: [{ element }],
+      };
+      (page as any).uuid = 'page-uuid';
+
+      const flow: ListingFlow = {
+        id: 'esg',
+        'url-key': 'esg',
+        name: 'ESG',
+        title: { de: 'ESG', en: 'ESG' },
+        icon: 'mdiFileOutline',
+        version: '1.2.3',
+        modules: [
+          {
+            id: 'heizlast',
+            name: { de: 'Heizlast', en: 'Heat load' },
+            description: { de: 'Heizlast-Modul', en: 'Heat load module' },
+            icon: 'mdiHeatingCoil',
+            default_active: false,
+            delivery: 'CATALOG',
+            version: '1.0.0',
+          },
+        ],
+        pages_edit: [page],
+        pages_view: [],
+      };
+
+      const exported = transformFlowForExport(flow);
+
+      // Modul-Katalog + flow-version bleiben unverändert erhalten
+      expect(exported.modules).toEqual(flow.modules);
+      expect(exported.version).toBe('1.2.3');
+
+      // module_id überlebt auf Page und Element
+      const exportedPage = exported.pages_edit[0];
+      expect(exportedPage.module_id).toBe('heizlast');
+      const exportedElement = exportedPage.elements[0].element as StringUIElement;
+      expect(exportedElement.module_id).toBe('heizlast');
+
+      // uuid wird gestrippt
+      expect((exportedPage as any).uuid).toBeUndefined();
+      expect(exportedElement.uuid).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
Der Toolkit kann jetzt das **Modul-System** aus portal-applications („Modulare Flows") authoren: Module deklarieren und Seiten/Elemente einem Modul zuordnen.

## Was drin ist
- **Typmodell** (Phase 1): `ListingFlow.modules` + neuer Typ `Module` (`id`, `name`, `description`, `icon`, `default_active`, `delivery` INLINE/CATALOG, `version`); `module_id` an `UIElementBase` (alle Elemente inkl. Group) und an `Page`; flow-level `version`. Alles snake_case, exakt wie das portal-REST/Customer-JSON.
- **Modul-Katalog-Manager** (Phase 2): neuer „Module"-Button → Dialog zum Anlegen/Bearbeiten/Löschen von Modulen (ID-Slug-Validierung mit Hinweis `module_<id>_active`, übersetzbarer Name/Beschreibung, Icon, `default_active`, `delivery`, `version` bei CATALOG). Reducer-Actions `ADD/UPDATE/REMOVE_MODULE` mit Undo/Redo.
- **Referenz-Integrität**: `REMOVE_MODULE` löst referenzierende `module_id` rekursiv über alle Seiten/Elemente; `UPDATE_MODULE` migriert Referenzen bei ID-Änderung.
- **Tagging** (Phase 3): „Modul-Zuordnung"-Dropdown im Property-Editor (alle Elementtypen) und im Seiten-Dialog; persistiert über die bestehenden `UPDATE_FLOW`/`UPDATE_PAGE`-Pfade. `UPDATE_PAGE` synchronisiert `module_id` auf die View-Seite.
- **Sichtbarkeit**: Modul-Badge an Element-Karten; Dropdowns erscheinen nur, wenn der Flow Module deklariert.
- **Round-Trip**: `modules` + `module_id` überleben Import→Edit→Export unverändert (nur `uuid` wird gestrippt).

## Topic
Feature

## Testen
1. `npm install` (CI nutzt `--legacy-peer-deps`) → `npm start`.
2. Einen Flow laden/anlegen → Button **„Module"** → Modul anlegen (z. B. ID `heizlast`, Name, Icon, `delivery` INLINE) → erscheint in der Liste; bearbeiten/löschen testen.
3. Ein Element auswählen → rechts unter „Allgemeine Eigenschaften" **„Modul-Zuordnung"** wählen → Badge „Modul: heizlast" erscheint an der Karte.
4. Eine Seite bearbeiten → im Dialog **„Modul-Zuordnung"** setzen.
5. Exportieren → JSON enthält `modules` und `module_id` (snake_case; „— Kein Modul —" entfernt das Feld) → Re-Import unverändert. Undo/Redo prüfen.
6. Modul löschen → referenzierende `module_id` werden entfernt (Inhalte bleiben erhalten).

## Verifikation
`npm test` grün (96 Tests, inkl. neuer Modul-/Page-Tagging-Tests), `tsc --noEmit` ohne Fehler, `npm run build` erfolgreich.

## Hinweise
- Der PR baut auf zwei gestapelten Branches auf und enthält Phase 1–3 zusammen, damit das Feature in einem Stück testbar ist.
- Bewusst **nicht** in diesem PR (Folge-Increments): referenzielle Validierungs-UI für verwaiste `module_id`, Authoring eigenständiger CATALOG-Modul-Artefakte, sowie der restliche Schema-Drift-Abgleich (z. B. `ContactUIElement`, erweiterte Subflow-Typen) — siehe `plans/modulare-flows-upgrade.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2Pc4cAexeqUFrM1YonaJL)_