### PR TITLE
Schema-Drift-Abgleich mit portal-applications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,8 @@ import {
   KeyValueListUIElement,
   ImageGalleryUIElement,
   FieldTextUIElement,
-  TableUIElement
+  TableUIElement,
+  ContactUIElement
 } from './models/uiElements';
 
 const theme = createTheme({
@@ -1590,6 +1591,22 @@ const createElement = (type: string): PatternLibraryElement => {
             en: 'Table'
           }
         } as TableUIElement
+      };
+
+    case 'ContactUIElement':
+      return {
+        element: {
+          pattern_type: 'ContactUIElement',
+          required: false,
+          identity_type: 'USER_ID',
+          show_name: true,
+          show_picture: true,
+          show_details: false,
+          title: {
+            de: 'Kontakt',
+            en: 'Contact'
+          }
+        } as ContactUIElement
       };
 
     default:

--- a/src/components/ElementPalette/ElementPalette.tsx
+++ b/src/components/ElementPalette/ElementPalette.tsx
@@ -19,7 +19,8 @@ import {
   Apartment as AdminBoundaryIcon,
   PhotoLibrary as ImageGalleryIcon,
   TextSnippet as FieldTextIcon,
-  TableChart as TableIcon
+  TableChart as TableIcon,
+  ContactMail as ContactIcon
 } from '@mui/icons-material';
 
 const PaletteContainer = styled(Paper)`
@@ -105,7 +106,8 @@ const elements: ElementType[] = [
   // View-Modus-spezifische Elemente
   { type: 'ImageGalleryUIElement', label: 'Bildergalerie (View)', icon: <ImageGalleryIcon />, category: 'view' },
   { type: 'FieldTextUIElement', label: 'Feldtext (View)', icon: <FieldTextIcon />, category: 'view' },
-  { type: 'TableUIElement', label: 'Tabelle (View)', icon: <TableIcon />, category: 'view' }
+  { type: 'TableUIElement', label: 'Tabelle (View)', icon: <TableIcon />, category: 'view' },
+  { type: 'ContactUIElement', label: 'Kontakt (View)', icon: <ContactIcon />, category: 'view' }
 ];
 
 // Implementierung mit Drag-and-Drop

--- a/src/components/PropertyEditor/ElementEditorFactory.tsx
+++ b/src/components/PropertyEditor/ElementEditorFactory.tsx
@@ -8,7 +8,8 @@ import {
   StringElementEditor,
   GroupElementEditor,
   ArrayElementEditor,
-  CustomElementEditor
+  CustomElementEditor,
+  ContactElementEditor
 } from './editors';
 import ChipGroupEditor from './editors/ChipGroupEditor';
 import SingleSelectionElementEditorEnhanced from './editors/SingleSelectionElementEditorEnhanced';
@@ -80,6 +81,9 @@ export const ElementEditorFactory: React.FC<ElementEditorFactoryProps> = ({ elem
 
     case 'CustomUIElement':
       return <CustomElementEditor element={element} onUpdate={onUpdate} />;
+
+    case 'ContactUIElement':
+      return <ContactElementEditor element={element} onUpdate={onUpdate} />;
 
     default:
       return (

--- a/src/components/PropertyEditor/editors/ContactElementEditor.tsx
+++ b/src/components/PropertyEditor/editors/ContactElementEditor.tsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  TextField,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  FormControlLabel,
+  Switch,
+  SelectChangeEvent,
+} from '@mui/material';
+import { PatternLibraryElement } from '../../../models/listingFlow';
+import { ContactUIElement } from '../../../models/uiElements';
+import TabbedTranslatableFields from '../common/TabbedTranslatableFields';
+import { AccordionSection } from '../common/AccordionSection';
+import { ElementTypeIndicator } from '../common/ElementTypeIndicator';
+import IconField from '../common/IconField';
+import ContactMailIcon from '@mui/icons-material/ContactMail';
+import TitleIcon from '@mui/icons-material/Title';
+import TuneIcon from '@mui/icons-material/Tune';
+
+interface ContactElementEditorProps {
+  element: PatternLibraryElement;
+  onUpdate: (updatedElement: PatternLibraryElement) => void;
+}
+
+/**
+ * Editor-Komponente für ContactUIElement (Kontakt-/Identitäts-Karte).
+ */
+const ContactElementEditor: React.FC<ContactElementEditorProps> = ({ element, onUpdate }) => {
+  const contactElement = element.element as ContactUIElement;
+  const [languageTab, setLanguageTab] = useState(0);
+
+  const update = (updates: Partial<ContactUIElement>) => {
+    onUpdate({ ...element, element: { ...contactElement, ...updates } });
+  };
+
+  return (
+    <>
+      <ElementTypeIndicator
+        type="Kontakt"
+        icon={<ContactMailIcon fontSize="large" color="primary" />}
+        description="Zeigt eine Kontakt-/Identitäts-Karte an (z. B. den zuständigen Berater)"
+      />
+
+      <AccordionSection title="Grundlegende Informationen" icon={<TitleIcon />} defaultExpanded={true}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TabbedTranslatableFields
+            fields={[
+              {
+                id: 'title',
+                label: 'Titel',
+                value: contactElement.title,
+                onChange: (value) => update({ title: value }),
+              },
+              {
+                id: 'description',
+                label: 'Beschreibung',
+                value: contactElement.description,
+                onChange: (value) => update({ description: value }),
+                multiline: true,
+                rows: 2,
+              },
+            ]}
+            languageTab={languageTab}
+            onLanguageTabChange={(newValue) => setLanguageTab(newValue)}
+          />
+
+          <IconField value={contactElement.icon || ''} onChange={(value) => update({ icon: value })} />
+        </Box>
+      </AccordionSection>
+
+      <AccordionSection title="Inhalt & Verhalten" icon={<TuneIcon />} defaultExpanded={true}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <FormControl fullWidth size="small">
+            <InputLabel id="contact-identity-type-label">Identitätstyp</InputLabel>
+            <Select
+              labelId="contact-identity-type-label"
+              label="Identitätstyp"
+              value={contactElement.identity_type || 'USER_ID'}
+              onChange={(e: SelectChangeEvent) => update({ identity_type: e.target.value })}
+            >
+              <MenuItem value="USER_ID">Benutzer (USER_ID)</MenuItem>
+              <MenuItem value="EDITOR_ID">Bearbeiter (EDITOR_ID)</MenuItem>
+              <MenuItem value="BILLING_GROUP_ID">Abrechnungsgruppe (BILLING_GROUP_ID)</MenuItem>
+            </Select>
+          </FormControl>
+
+          <TextField
+            label="Feld-ID (field_value)"
+            size="small"
+            fullWidth
+            value={contactElement.field_value?.field_id?.field_name || ''}
+            onChange={(e) =>
+              update({ field_value: { field_id: { field_name: e.target.value } } })
+            }
+            helperText="Feld, das die anzuzeigende Identität referenziert."
+          />
+
+          <FormControlLabel
+            control={
+              <Switch
+                checked={!!contactElement.show_name}
+                onChange={(e) => update({ show_name: e.target.checked })}
+              />
+            }
+            label="Name anzeigen"
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={!!contactElement.show_picture}
+                onChange={(e) => update({ show_picture: e.target.checked })}
+              />
+            }
+            label="Bild anzeigen"
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={!!contactElement.show_details}
+                onChange={(e) => update({ show_details: e.target.checked })}
+              />
+            }
+            label="Details anzeigen"
+          />
+        </Box>
+      </AccordionSection>
+    </>
+  );
+};
+
+export default ContactElementEditor;

--- a/src/components/PropertyEditor/editors/DateElementEditor.tsx
+++ b/src/components/PropertyEditor/editors/DateElementEditor.tsx
@@ -78,6 +78,8 @@ const DateElementEditor: React.FC<DateElementEditorProps> = ({ element, onUpdate
         return 'Format: YYYY-MM (z.B. 2023-01)';
       case 'YMD':
         return 'Format: YYYY-MM-DD (z.B. 2023-01-15)';
+      case 'YMDT':
+        return 'Format: YYYY-MM-DDTHH:mm (z.B. 2023-01-15T14:30)';
       default:
         return 'Format abhängig vom gewählten Typ';
     }
@@ -94,6 +96,8 @@ const DateElementEditor: React.FC<DateElementEditorProps> = ({ element, onUpdate
         return 'month';
       case 'YMD':
         return 'date';
+      case 'YMDT':
+        return 'datetime-local';
       default:
         return 'text';
     }
@@ -182,6 +186,7 @@ const DateElementEditor: React.FC<DateElementEditorProps> = ({ element, onUpdate
               <MenuItem value="Y">Jahr</MenuItem>
               <MenuItem value="YM">Jahr &amp; Monat</MenuItem>
               <MenuItem value="YMD">Datum (Jahr-Monat-Tag)</MenuItem>
+              <MenuItem value="YMDT">Datum &amp; Uhrzeit</MenuItem>
             </Select>
             <FormHelperText>
               {getHelperTextForDateType(dateElement.type || 'Y')}

--- a/src/components/PropertyEditor/editors/index.ts
+++ b/src/components/PropertyEditor/editors/index.ts
@@ -10,3 +10,4 @@ export { default as StringElementEditor } from './StringElementEditor';
 export { default as GroupElementEditor } from './GroupElementEditor';
 export { default as ArrayElementEditor } from './ArrayElementEditor';
 export { default as CustomElementEditor } from './CustomElementEditor';
+export { default as ContactElementEditor } from './ContactElementEditor';

--- a/src/models/uiElements.ts
+++ b/src/models/uiElements.ts
@@ -15,7 +15,8 @@ export type UIElement =
   | KeyValueListUIElement
   | ImageGalleryUIElement
   | FieldTextUIElement
-  | TableUIElement;
+  | TableUIElement
+  | ContactUIElement;
 
 export interface TextUIElement extends UIElementEdit {
   pattern_type: 'TextUIElement';
@@ -89,7 +90,7 @@ export interface NumberUIElement extends UIElementEdit {
 export interface DateUIElement extends UIElementEdit {
   pattern_type: 'DateUIElement';
   field_id: FieldId;
-  type: 'Y' | 'YM' | 'YMD';
+  type: 'Y' | 'YM' | 'YMD' | 'YMDT';
   minimum?: string;
   maximum?: string;
   default_value?: string;
@@ -129,8 +130,29 @@ export interface CustomUIElement extends UIElementEdit {
   sub_flows?: SubFlow[];
 }
 
+// SubFlow-Typen müssen mit portal-applications übereinstimmen
+// (customers/schema/readme.md). 'SLAB' ist ein Legacy-Wert und bleibt aus
+// Kompatibilitätsgründen erhalten.
+export type SubFlowType =
+  | 'POI_PHOTO'
+  | 'POI'
+  | 'ROOM'
+  | 'ROOM_GROUP'
+  | 'WINDOW'
+  | 'WINDOW_GROUP'
+  | 'DOOR'
+  | 'DOOR_GROUP'
+  | 'WALL'
+  | 'WALL_GROUP'
+  | 'WALL_EVEBI'
+  | 'ROOF_AREA'
+  | 'FLOOR'
+  | 'FLOOR_SLAB'
+  | 'BUILDING'
+  | 'SLAB';
+
 export interface SubFlow {
-  type: 'SLAB' | 'WINDOW' | 'DOOR' | 'WALL' | 'ROOM' | 'ROOM_GROUP' | 'POI' | 'POI_PHOTO';
+  type: SubFlowType;
   elements: any[]; // PatternLibraryElement[]
 }
 
@@ -190,4 +212,21 @@ export interface TableUIElement extends UIElementEdit {
 export interface TableColumn {
   header: TranslatableString;
   field_value: { field_id: FieldId };
+}
+
+/**
+ * Zeigt eine Kontakt-/Identitäts-Karte an (z. B. den zuständigen Energieberater).
+ * Entspricht ContactUIElement aus portal-applications (REST/Customer-JSON, snake_case).
+ */
+export interface ContactUIElement extends UIElementEdit {
+  pattern_type: 'ContactUIElement';
+  // Feld, das die anzuzeigende Identität referenziert.
+  field_value?: { field_id: FieldId };
+  // Welche Identität angezeigt wird.
+  identity_type: 'USER_ID' | 'EDITOR_ID' | 'BILLING_GROUP_ID' | string;
+  // Was von der Identität angezeigt wird.
+  show_name?: boolean;
+  show_picture?: boolean;
+  show_details?: boolean;
+  preferred_position?: string;
 }

--- a/src/utils/uuidUtils.test.ts
+++ b/src/utils/uuidUtils.test.ts
@@ -464,4 +464,39 @@ describe('uuidUtils', () => {
       expect(exportedElement.uuid).toBeUndefined();
     });
   });
+
+  describe('Schema-Drift: ContactUIElement', () => {
+    it('erhält ContactUIElement-Felder beim Export-Round-Trip', () => {
+      const contact: any = {
+        pattern_type: 'ContactUIElement',
+        required: false,
+        identity_type: 'USER_ID',
+        show_name: true,
+        show_picture: true,
+        show_details: false,
+        field_value: { field_id: { field_name: 'advisor_id' } },
+        title: { de: 'Berater', en: 'Advisor' },
+      };
+
+      const flow: ListingFlow = {
+        id: 'c',
+        'url-key': 'c',
+        name: 'C',
+        title: { de: 'C', en: 'C' },
+        icon: 'mdiFileOutline',
+        pages_edit: [
+          { pattern_type: 'Page', id: 'p1', title: { de: 'P1', en: 'P1' }, elements: [{ element: contact }] },
+        ],
+        pages_view: [],
+      };
+
+      const exported = transformFlowForExport(flow);
+      const el = exported.pages_edit[0].elements[0].element as any;
+      expect(el.pattern_type).toBe('ContactUIElement');
+      expect(el.identity_type).toBe('USER_ID');
+      expect(el.show_name).toBe(true);
+      expect(el.field_value).toEqual({ field_id: { field_name: 'advisor_id' } });
+      expect(el.uuid).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
Schließt die bekannten Schema-Lücken zwischen Toolkit und portal-applications, damit Flows mit diesen Elementen nicht mehr „unbekannt"/nicht editierbar sind.

## Was drin ist
- **ContactUIElement** (in portal vorhanden, im Toolkit bisher fehlend): Typ ergänzt + Editor (`identity_type` USER_ID/EDITOR_ID/BILLING_GROUP_ID, `field_value`, `show_name`/`show_picture`/`show_details`) + Registrierung in Factory + Palette („Kontakt (View)") + Default-Element.
- **SubFlow-Typen** an portal angeglichen (`customers/schema/readme.md`): `POI_PHOTO`, `POI`, `ROOM`, `ROOM_GROUP`, `WINDOW`, `WINDOW_GROUP`, `DOOR`, `DOOR_GROUP`, `WALL`, `WALL_GROUP`, `WALL_EVEBI`, `ROOF_AREA`, `FLOOR`, `FLOOR_SLAB`, `BUILDING` — Legacy-Wert `SLAB` bleibt erhalten.
- **DateUIElement**: Typ `YMDT` (Datum & Uhrzeit) ergänzt — im Editor-Select sowie Format-/Input-Logik (`datetime-local`).

## Topic
Refactoring / Feature

## Testen
1. `npm install --legacy-peer-deps` → `npm start`.
2. Palette → Tab „View" → **Kontakt (View)** in eine Seite ziehen → rechts Identitätstyp/Felder/Schalter setzen → exportieren → JSON enthält `ContactUIElement` mit `identity_type`, `show_*`, `field_value` (snake_case).
3. Ein Datums-Element wählen → Typ **„Datum & Uhrzeit" (YMDT)** → Format/Eingabe passt.
4. Einen Flow mit erweiterten Subflow-Typen (z. B. `WALL_EVEBI`, `ROOF_AREA`) importieren → Round-Trip unverändert.

## Verifikation
`npm test` grün (97 Tests, inkl. ContactUIElement-Round-Trip-Test), `tsc --noEmit` ohne Fehler, `npm run build` erfolgreich.

## Hinweis
Round-Trip-Fidelität bleibt gewahrt: unbekannte/zusätzliche Felder überstehen Import→Export weiterhin unverändert (nur `uuid` wird gestrippt). Restliche offene Punkte siehe `plans/modulare-flows-upgrade.md` (Phase 5 Validierung, Phase 7 CATALOG-Artefakte).

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2Pc4cAexeqUFrM1YonaJL)_