### PR TITLE
Modulare Flows: Validierung verwaister Modul-Zuordnungen

### DIFF
--- a/src/components/HybridEditor/EnhancedPropertyEditor.tsx
+++ b/src/components/HybridEditor/EnhancedPropertyEditor.tsx
@@ -192,8 +192,8 @@ const EnhancedPropertyEditor: React.FC<EnhancedPropertyEditorProps> = ({
             </FormField>
           )}
 
-          {/* Modul-Zuordnung (nur wenn der Flow Module deklariert) */}
-          {modules.length > 0 && (
+          {/* Modul-Zuordnung (wenn der Flow Module deklariert oder dieses Element bereits getaggt ist) */}
+          {(modules.length > 0 || (element.element as any).module_id) && (
             <FormField>
               <FormControl fullWidth size="small">
                 <InputLabel id="module-id-select-label">Modul-Zuordnung</InputLabel>
@@ -211,6 +211,12 @@ const EnhancedPropertyEditor: React.FC<EnhancedPropertyEditorProps> = ({
                       {module.name?.de || module.name?.en || module.id}
                     </MenuItem>
                   ))}
+                  {(element.element as any).module_id &&
+                    !modules.some((m) => m.id === (element.element as any).module_id) && (
+                      <MenuItem value={(element.element as any).module_id}>
+                        {`⚠ Unbekannt: ${(element.element as any).module_id}`}
+                      </MenuItem>
+                    )}
                 </Select>
                 <FormHelperText>
                   Element nur sichtbar, wenn das zugeordnete Modul aktiv ist.

--- a/src/components/ModuleManager/ModuleManagerDialog.tsx
+++ b/src/components/ModuleManager/ModuleManagerDialog.tsx
@@ -20,6 +20,7 @@ import {
   InputLabel,
   Divider,
   Stack,
+  Alert,
   useMediaQuery,
   useTheme,
 } from '@mui/material';
@@ -32,6 +33,7 @@ import { TabbedTranslatableFields } from '../PropertyEditor/common/TabbedTransla
 import IconField from '../PropertyEditor/common/IconField';
 import { useEditor } from '../../context/EditorContext';
 import { Module } from '../../models/listingFlow';
+import { danglingModuleIds } from '../../utils/moduleValidation';
 
 interface ModuleManagerDialogProps {
   open: boolean;
@@ -61,6 +63,7 @@ const ModuleManagerDialog: React.FC<ModuleManagerDialogProps> = ({ open, onClose
   const { state, dispatch } = useEditor();
 
   const modules = state.currentFlow?.modules ?? [];
+  const dangling = danglingModuleIds(state.currentFlow);
 
   // Editor-Sub-Dialog (Anlegen/Bearbeiten)
   const [editorOpen, setEditorOpen] = useState(false);
@@ -129,6 +132,16 @@ const ModuleManagerDialog: React.FC<ModuleManagerDialogProps> = ({ open, onClose
             später per Modul-Zuordnung einem Modul zugewiesen und sind nur sichtbar, wenn das Projekt
             das Modul aktiviert hat.
           </Typography>
+
+          {dangling.length > 0 && (
+            <Alert severity="warning" sx={{ mb: 2 }}>
+              {dangling.length === 1
+                ? 'Eine Modul-Zuordnung verweist auf ein nicht (mehr) vorhandenes Modul: '
+                : 'Mehrere Modul-Zuordnungen verweisen auf nicht (mehr) vorhandene Module: '}
+              <strong>{dangling.join(', ')}</strong>. Lege die fehlenden Module an oder entferne die
+              Zuordnung an den betroffenen Seiten/Elementen.
+            </Alert>
+          )}
 
           {modules.length === 0 ? (
             <Box

--- a/src/components/PageNavigator/EditPageDialog.tsx
+++ b/src/components/PageNavigator/EditPageDialog.tsx
@@ -483,8 +483,8 @@ const EditPageDialog: React.FC<EditPageDialogProps> = ({
               </FormHelperText>
             </FormControl>
 
-            {/* Modul-Zuordnung (nur wenn der Flow Module deklariert) */}
-            {(state.currentFlow?.modules?.length ?? 0) > 0 && (
+            {/* Modul-Zuordnung (wenn der Flow Module deklariert oder die Seite bereits getaggt ist) */}
+            {((state.currentFlow?.modules?.length ?? 0) > 0 || moduleId) && (
               <FormControl fullWidth margin="dense" sx={{ mb: 3 }}>
                 <InputLabel id="page-module-select-label">Modul-Zuordnung</InputLabel>
                 <Select
@@ -502,6 +502,10 @@ const EditPageDialog: React.FC<EditPageDialogProps> = ({
                       {module.name?.de || module.name?.en || module.id}
                     </MenuItem>
                   ))}
+                  {moduleId &&
+                    !(state.currentFlow?.modules ?? []).some((m) => m.id === moduleId) && (
+                      <MenuItem value={moduleId}>{`⚠ Unbekannt: ${moduleId}`}</MenuItem>
+                    )}
                 </Select>
                 <FormHelperText>
                   Seite nur sichtbar, wenn das zugeordnete Modul aktiv ist.

--- a/src/utils/moduleValidation.test.ts
+++ b/src/utils/moduleValidation.test.ts
@@ -1,0 +1,88 @@
+import { collectModuleReferences, findDanglingModuleReferences, danglingModuleIds } from './moduleValidation';
+import { ListingFlow } from '../models/listingFlow';
+
+const makeFlow = (overrides: Partial<ListingFlow>): ListingFlow => ({
+  id: 'f',
+  'url-key': 'f',
+  name: 'F',
+  title: { de: 'F', en: 'F' },
+  icon: 'mdiFileOutline',
+  pages_edit: [],
+  pages_view: [],
+  ...overrides,
+});
+
+describe('moduleValidation', () => {
+  it('sammelt module_id-Referenzen von Seiten und (verschachtelten) Elementen', () => {
+    const flow = makeFlow({
+      modules: [
+        { id: 'heizlast', name: { de: 'Heizlast' }, description: { de: '' } },
+      ],
+      pages_edit: [
+        {
+          pattern_type: 'Page',
+          id: 'p1',
+          title: { de: 'Seite 1' },
+          module_id: 'heizlast',
+          elements: [
+            {
+              element: {
+                pattern_type: 'GroupUIElement',
+                required: false,
+                title: { de: 'Gruppe' },
+                module_id: 'heizlast',
+                elements: [
+                  { element: { pattern_type: 'StringUIElement', type: 'TEXT', required: false, title: { de: 'Feld' }, module_id: 'heizlast', field_id: { field_name: 'x' } } },
+                ],
+              } as any,
+            },
+          ],
+        },
+      ],
+    });
+
+    const refs = collectModuleReferences(flow);
+    expect(refs).toHaveLength(3); // Seite + Gruppe + verschachteltes Feld
+    expect(refs.every((r) => r.moduleId === 'heizlast')).toBe(true);
+  });
+
+  it('erkennt verwaiste Referenzen (module_id ohne Katalog-Eintrag)', () => {
+    const flow = makeFlow({
+      modules: [{ id: 'heizlast', name: { de: 'Heizlast' }, description: { de: '' } }],
+      pages_edit: [
+        {
+          pattern_type: 'Page',
+          id: 'p1',
+          title: { de: 'Seite 1' },
+          elements: [
+            { element: { pattern_type: 'StringUIElement', type: 'TEXT', required: false, title: { de: 'Feld' }, module_id: 'unbekannt', field_id: { field_name: 'x' } } as any },
+          ],
+        },
+      ],
+    });
+
+    const dangling = findDanglingModuleReferences(flow);
+    expect(dangling).toHaveLength(1);
+    expect(dangling[0].moduleId).toBe('unbekannt');
+    expect(danglingModuleIds(flow)).toEqual(['unbekannt']);
+  });
+
+  it('behandelt alle Referenzen als verwaist, wenn kein Modul-Katalog existiert', () => {
+    const flow = makeFlow({
+      pages_edit: [
+        { pattern_type: 'Page', id: 'p1', title: { de: 'Seite 1' }, module_id: 'heizlast', elements: [] },
+      ],
+    });
+    expect(findDanglingModuleReferences(flow)).toHaveLength(1);
+  });
+
+  it('liefert keine verwaisten Referenzen, wenn alle module_id im Katalog existieren', () => {
+    const flow = makeFlow({
+      modules: [{ id: 'heizlast', name: { de: 'Heizlast' }, description: { de: '' } }],
+      pages_edit: [
+        { pattern_type: 'Page', id: 'p1', title: { de: 'Seite 1' }, module_id: 'heizlast', elements: [] },
+      ],
+    });
+    expect(findDanglingModuleReferences(flow)).toHaveLength(0);
+  });
+});

--- a/src/utils/moduleValidation.ts
+++ b/src/utils/moduleValidation.ts
@@ -1,0 +1,80 @@
+import { ListingFlow, Page, PatternLibraryElement } from '../models/listingFlow';
+
+/**
+ * Eine Stelle im Flow, die per `module_id` auf ein Modul verweist.
+ */
+export interface ModuleReference {
+  moduleId: string;
+  /** Menschenlesbare Fundstelle (für Warnungen). */
+  location: string;
+}
+
+const collectFromElement = (
+  ple: PatternLibraryElement,
+  pageLabel: string,
+  acc: ModuleReference[]
+): void => {
+  const el = ple?.element as any;
+  if (!el) return;
+
+  if (el.module_id) {
+    const label = el.title?.de || el.title?.en || el.pattern_type || 'Element';
+    acc.push({ moduleId: el.module_id, location: `Element „${label}" (${pageLabel})` });
+  }
+
+  if (Array.isArray(el.elements)) {
+    el.elements.forEach((child: PatternLibraryElement) => collectFromElement(child, pageLabel, acc));
+  }
+  if (Array.isArray(el.sub_flows)) {
+    el.sub_flows.forEach((sf: any) => {
+      if (Array.isArray(sf?.elements)) {
+        sf.elements.forEach((child: PatternLibraryElement) => collectFromElement(child, pageLabel, acc));
+      }
+    });
+  }
+  if (Array.isArray(el.chips)) {
+    el.chips.forEach((chip: any) => {
+      if (chip?.module_id) {
+        acc.push({ moduleId: chip.module_id, location: `Chip (${pageLabel})` });
+      }
+    });
+  }
+};
+
+const collectFromPages = (pages: Page[] | undefined, acc: ModuleReference[]): void => {
+  (pages ?? []).forEach((page) => {
+    const pageLabel = `Seite „${page.title?.de || page.id}"`;
+    if ((page as any).module_id) {
+      acc.push({ moduleId: (page as any).module_id, location: pageLabel });
+    }
+    (page.elements ?? []).forEach((child) => collectFromElement(child, pageLabel, acc));
+  });
+};
+
+/**
+ * Sammelt alle `module_id`-Referenzen im Flow (Seiten + verschachtelte Elemente).
+ */
+export const collectModuleReferences = (flow: ListingFlow | null): ModuleReference[] => {
+  if (!flow) return [];
+  const acc: ModuleReference[] = [];
+  collectFromPages(flow.pages_edit, acc);
+  collectFromPages(flow.pages_view, acc);
+  return acc;
+};
+
+/**
+ * Liefert alle Referenzen, deren `module_id` in `ListingFlow.modules` NICHT existiert
+ * (verwaiste Referenzen / dangling references). Wenn der Modul-Katalog fehlt, gelten
+ * alle Referenzen als verwaist.
+ */
+export const findDanglingModuleReferences = (flow: ListingFlow | null): ModuleReference[] => {
+  if (!flow) return [];
+  const known = new Set((flow.modules ?? []).map((m) => m.id));
+  return collectModuleReferences(flow).filter((ref) => !known.has(ref.moduleId));
+};
+
+/**
+ * Eindeutige, verwaiste Modul-IDs (für kompakte Warnungen).
+ */
+export const danglingModuleIds = (flow: ListingFlow | null): string[] =>
+  Array.from(new Set(findDanglingModuleReferences(flow).map((r) => r.moduleId)));


### PR DESCRIPTION
Macht verwaiste `module_id`-Zuordnungen (z. B. nach Import oder nach Umbenennen/Löschen eines Moduls extern) sichtbar und gefahrlos editierbar.

## Was drin ist
- **Validierungs-Util** (`src/utils/moduleValidation.ts`): `collectModuleReferences` / `findDanglingModuleReferences` / `danglingModuleIds` — sammelt rekursiv alle `module_id` über Seiten + verschachtelte Elemente und meldet jene, die nicht in `ListingFlow.modules` existieren (fehlender Katalog ⇒ alle verwaist).
- **Modul-Manager**: Warn-Alert listet verwaiste Modul-IDs mit Handlungsaufforderung.
- **Property-Editor & Seiten-Dialog**: ein unbekannter (verwaister) `module_id` erscheint als „⚠ Unbekannt: …"-Eintrag; das Dropdown wird auch ohne Katalog eingeblendet, solange ein Wert gesetzt ist → kein stiller Datenverlust, keine MUI-„out-of-range"-Warnung, Zuordnung lässt sich gezielt korrigieren oder entfernen.

## Topic
Feature

## Testen
1. `npm install --legacy-peer-deps` → `npm start`.
2. Einen Flow importieren/erzeugen, in dem ein Element/eine Seite ein `module_id` trägt, das **nicht** im `modules`-Katalog steht (z. B. Modul vorher extern entfernt).
3. **„Module"** öffnen → oben erscheint ein Warn-Alert mit den verwaisten IDs.
4. Element/Seite auswählen → „Modul-Zuordnung" zeigt „⚠ Unbekannt: …" und lässt sich auf „— Kein Modul —" oder ein vorhandenes Modul ändern.

## Verifikation
`npm test` grün (inkl. 4 neuer `moduleValidation`-Tests), `tsc --noEmit` ohne Fehler, `npm run build` erfolgreich.

## Hinweis
Nur Erkennung/Anzeige — es wird nichts automatisch gelöscht. Nächstes geplantes Increment: Phase 7 (Authoring eigenständiger CATALOG-Modul-Artefakte), siehe `plans/modulare-flows-upgrade.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2Pc4cAexeqUFrM1YonaJL)_