### PR TITLE
Modulare Flows: CATALOG-Artefakte + Finalisierung

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ ListingFlow { id, url-key, name, title, icon, modules?, pages_edit[], pages_view
 
 ## Modulare Flows (Kontext)
 
-portal unterstützt seit Juni 2026 **Module**: Ein Flow kann einen `modules`-Katalog deklarieren; Seiten/Gruppen/Elemente werden per `module_id` einem Modul zugeordnet und sind nur sichtbar, wenn das Projekt das Modul aktiviert hat (`module_<id>_active === true`). Module werden **INLINE** (im Basis-Flow) oder **CATALOG** (separates, nachladbares, versioniertes Flow-Artefakt) ausgeliefert. Der Toolkit muss dieses Authoring abbilden — Detailplan in `plans/modulare-flows-upgrade.md`.
+portal unterstützt seit Juni 2026 **Module**: Ein Flow kann einen `modules`-Katalog deklarieren; Seiten/Gruppen/Elemente werden per `module_id` einem Modul zugeordnet und sind nur sichtbar, wenn das Projekt das Modul aktiviert hat (`module_<id>_active === true`). Module werden **INLINE** (im Basis-Flow) oder **CATALOG** (separates, nachladbares, versioniertes Flow-Artefakt) ausgeliefert. Der Toolkit bildet dieses Authoring ab: Modul-Katalog-Manager (Button „Module"), `module_id`-Zuordnung in Property-Editor & Seiten-Dialog, Badges, Validierung verwaister Zuordnungen und Export/Import einzelner CATALOG-Artefakte. Umsetzungsstand & Details: `plans/modulare-flows-upgrade.md`.
 
 ## Tests
 

--- a/plans/modulare-flows-upgrade.md
+++ b/plans/modulare-flows-upgrade.md
@@ -2,6 +2,23 @@
 
 > Ziel: Den Visual-Editor so erweitern, dass er die neue **Modulare-Flows**-Fähigkeit von `portal-applications` authoren kann, und gleichzeitig die sonstige **Schema-Drift** toolkit↔portal schließen. UX/UI produktreif, mit Blick auf eine künftige Integration des Toolkits in portal-applications.
 
+## Umsetzungsstand (Stand 2026-06-14)
+
+| Phase | Inhalt | Status |
+|---|---|---|
+| 0 | Schema als Vertrag (AJV lässt neue Felder zu / Round-Trip) | ✅ (durch Round-Trip-Erhalt abgedeckt) |
+| 1 | Typmodell (`modules`, `Module`, `module_id`, flow-`version`) | ✅ |
+| 2 | Modul-Katalog-Manager (CRUD + Referenz-Integrität) | ✅ |
+| 3 | `module_id`-Tagging an Seiten & Elementen | ✅ |
+| 4 | Visuelle Kennzeichnung (Badge an Element-Karten **und** Page-Tabs) | ✅ |
+| 5 | Referenzielle Validierung (verwaiste `module_id`) | ✅ |
+| 6 | Import/Export-Round-Trip (`modules`/`module_id` überleben) | ✅ |
+| 7 | CATALOG-Modul-Artefakte exportieren/importieren | ✅ |
+| 8 | Schema-Drift-Abgleich (`ContactUIElement`, SubFlow-Typen, `DateUIElement 'YMDT'`) | ✅ |
+| 9 | Produkt-UX-Politur + Vorbereitung portal-Integration | teilweise (Kern-UX umgesetzt; tiefe CRA/Craco-Entkopplung als Future Work) |
+
+Offen / Future Work: optionaler Modul-Filter/Highlight + Legende; Entkopplung des Editor-Kerns von CRA/Craco für die spätere Einbettung in die Vue-PWA.
+
 ## Hintergrund
 
 `portal-applications` rendert seine gesamte Erfassungs-UI aus Flow-JSON (`ListingFlow` → `pages_edit`/`pages_view` → `elements` → UIElement-Typen; `CustomUIElement.sub_flows`; `visibility_condition`). Der Toolkit erzeugt genau dieses JSON.

--- a/src/components/ModuleManager/ModuleManagerDialog.tsx
+++ b/src/components/ModuleManager/ModuleManagerDialog.tsx
@@ -27,13 +27,17 @@ import {
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import FileUploadIcon from '@mui/icons-material/FileUpload';
 import Icon from '@mdi/react';
 import { getIconPath } from '../../utils/mdiIcons';
 import { TabbedTranslatableFields } from '../PropertyEditor/common/TabbedTranslatableFields';
 import IconField from '../PropertyEditor/common/IconField';
 import { useEditor } from '../../context/EditorContext';
-import { Module } from '../../models/listingFlow';
+import { Module, ListingFlow } from '../../models/listingFlow';
 import { danglingModuleIds } from '../../utils/moduleValidation';
+import { extractModuleArtifact, mergeModuleArtifact } from '../../utils/moduleArtifact';
+import { transformFlowForExport } from '../../utils/uuidUtils';
 
 interface ModuleManagerDialogProps {
   open: boolean;
@@ -114,6 +118,46 @@ const ModuleManagerDialog: React.FC<ModuleManagerDialogProps> = ({ open, onClose
     setConfirmDeleteId(null);
   };
 
+  // Exportiert ein Modul als eigenständiges CATALOG-Artefakt (flow-förmige JSON).
+  const handleExportArtifact = (moduleId: string) => {
+    const artifact = extractModuleArtifact(state.currentFlow, moduleId);
+    if (!artifact) return;
+    const json = JSON.stringify(transformFlowForExport(artifact), null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${moduleId}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  // Importiert ein Modul-Artefakt und führt es in den aktuellen Flow zusammen.
+  const handleImportArtifact = () => {
+    if (!state.currentFlow) return;
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'application/json,.json';
+    input.onchange = (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        try {
+          const artifact = JSON.parse(event.target?.result as string) as ListingFlow;
+          const merged = mergeModuleArtifact(state.currentFlow!, artifact);
+          dispatch({ type: 'UPDATE_FLOW', flow: merged });
+        } catch {
+          // Ungültige Datei – still ignorieren (Fehleranzeige erfolgt über bestehende Mechanismen)
+        }
+      };
+      reader.readAsText(file);
+    };
+    input.click();
+  };
+
   const renderModuleIcon = (iconName?: string) => {
     if (!iconName || !iconName.startsWith('mdi')) return null;
     const path = getIconPath(iconName);
@@ -188,6 +232,14 @@ const ModuleManagerDialog: React.FC<ModuleManagerDialogProps> = ({ open, onClose
                         </IconButton>
                         <IconButton
                           size="small"
+                          onClick={() => handleExportArtifact(module.id)}
+                          aria-label="Als Artefakt exportieren"
+                          title="Als CATALOG-Artefakt exportieren"
+                        >
+                          <FileDownloadIcon fontSize="small" />
+                        </IconButton>
+                        <IconButton
+                          size="small"
                           color="error"
                           onClick={() => setConfirmDeleteId(module.id)}
                           aria-label="Löschen"
@@ -202,9 +254,14 @@ const ModuleManagerDialog: React.FC<ModuleManagerDialogProps> = ({ open, onClose
             </Stack>
           )}
 
-          <Button startIcon={<AddIcon />} onClick={handleOpenAdd} sx={{ mt: 2 }}>
-            Modul hinzufügen
-          </Button>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 2 }}>
+            <Button startIcon={<AddIcon />} onClick={handleOpenAdd}>
+              Modul hinzufügen
+            </Button>
+            <Button startIcon={<FileUploadIcon />} onClick={handleImportArtifact}>
+              Artefakt importieren
+            </Button>
+          </Box>
         </DialogContent>
         <DialogActions>
           <Button onClick={onClose}>Schließen</Button>

--- a/src/components/PageNavigator/PageTab.tsx
+++ b/src/components/PageNavigator/PageTab.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 import { Tab, Tooltip, Box, Menu, MenuItem, ListItemIcon, ListItemText } from '@mui/material';
-import { Delete as DeleteIcon, Edit as EditIcon, Visibility as VisibilityIcon, AccountTree as AccountTreeIcon, MoreVert as MoreVertIcon, DragIndicator as DragIndicatorIcon } from '@mui/icons-material';
+import { Delete as DeleteIcon, Edit as EditIcon, Visibility as VisibilityIcon, AccountTree as AccountTreeIcon, MoreVert as MoreVertIcon, DragIndicator as DragIndicatorIcon, Extension as ModuleIcon } from '@mui/icons-material';
 import Icon from '@mdi/react';
 import { getIconPath } from '../../utils/mdiIcons';
 import { Page } from '../../models/listingFlow';
@@ -193,6 +193,15 @@ const PageTab: React.FC<PageTabProps> = ({
                 <AccountTreeIcon
                   fontSize="small"
                   color="success"
+                  sx={{ ml: 0.5, opacity: 0.7 }}
+                />
+              </Tooltip>
+            )}
+            {(page as any).module_id && (
+              <Tooltip title={`Modul: ${(page as any).module_id}`}>
+                <ModuleIcon
+                  fontSize="small"
+                  color="info"
                   sx={{ ml: 0.5, opacity: 0.7 }}
                 />
               </Tooltip>

--- a/src/utils/moduleArtifact.test.ts
+++ b/src/utils/moduleArtifact.test.ts
@@ -1,0 +1,66 @@
+import { extractModuleArtifact, mergeModuleArtifact } from './moduleArtifact';
+import { ListingFlow } from '../models/listingFlow';
+
+const baseFlow = (): ListingFlow => ({
+  id: 'esg',
+  'url-key': 'esg',
+  name: 'ESG',
+  title: { de: 'ESG', en: 'ESG' },
+  icon: 'mdiFileOutline',
+  modules: [
+    { id: 'heizlast', name: { de: 'Heizlast', en: 'Heat load' }, description: { de: '' }, delivery: 'CATALOG', version: '1.0.0', icon: 'mdiHeatingCoil' },
+  ],
+  pages_edit: [
+    { pattern_type: 'CustomUIElement', id: 'edit-base', title: { de: 'Basis' }, elements: [] },
+    { pattern_type: 'CustomUIElement', id: 'edit-heizlast', title: { de: 'Heizlast' }, module_id: 'heizlast', elements: [] },
+  ],
+  pages_view: [
+    { pattern_type: 'CustomUIElement', id: 'view-heizlast', title: { de: 'Heizlast' }, module_id: 'heizlast', elements: [] },
+  ],
+});
+
+describe('moduleArtifact', () => {
+  describe('extractModuleArtifact', () => {
+    it('baut ein eigenständiges Artefakt mit Modul, Version und modul-getaggten Seiten', () => {
+      const artifact = extractModuleArtifact(baseFlow(), 'heizlast')!;
+      expect(artifact).not.toBeNull();
+      expect(artifact.id).toBe('heizlast');
+      expect(artifact.version).toBe('1.0.0');
+      expect(artifact.modules).toHaveLength(1);
+      expect(artifact.modules![0].delivery).toBe('CATALOG');
+      // nur die heizlast-getaggten Seiten
+      expect(artifact.pages_edit.map((p) => p.id)).toEqual(['edit-heizlast']);
+      expect(artifact.pages_view.map((p) => p.id)).toEqual(['view-heizlast']);
+    });
+
+    it('gibt null zurück für ein unbekanntes Modul', () => {
+      expect(extractModuleArtifact(baseFlow(), 'unbekannt')).toBeNull();
+    });
+  });
+
+  describe('mergeModuleArtifact', () => {
+    it('ergänzt Modul-Katalog und Seiten ohne Duplikate', () => {
+      const target: ListingFlow = {
+        id: 't',
+        'url-key': 't',
+        name: 'T',
+        title: { de: 'T', en: 'T' },
+        icon: 'mdiFileOutline',
+        modules: [],
+        pages_edit: [{ pattern_type: 'CustomUIElement', id: 'edit-base', title: { de: 'Basis' }, elements: [] }],
+        pages_view: [],
+      };
+      const artifact = extractModuleArtifact(baseFlow(), 'heizlast')!;
+
+      const merged = mergeModuleArtifact(target, artifact);
+      expect(merged.modules!.map((m) => m.id)).toEqual(['heizlast']);
+      expect(merged.pages_edit.map((p) => p.id)).toEqual(['edit-base', 'edit-heizlast']);
+      expect(merged.pages_view.map((p) => p.id)).toEqual(['view-heizlast']);
+
+      // Erneutes Mergen erzeugt keine Duplikate
+      const mergedTwice = mergeModuleArtifact(merged, artifact);
+      expect(mergedTwice.modules!.map((m) => m.id)).toEqual(['heizlast']);
+      expect(mergedTwice.pages_edit.map((p) => p.id)).toEqual(['edit-base', 'edit-heizlast']);
+    });
+  });
+});

--- a/src/utils/moduleArtifact.ts
+++ b/src/utils/moduleArtifact.ts
@@ -1,0 +1,65 @@
+import { ListingFlow, Module, Page } from '../models/listingFlow';
+
+/**
+ * Baut aus einem Basis-Flow ein eigenständiges CATALOG-Modul-Artefakt für ein Modul.
+ *
+ * Ein Artefakt ist selbst flow-förmig (gleiches ListingFlow-Schema, wie es
+ * portal-applications über `flowModule(id)` nachlädt). Es enthält:
+ *  - den Modul-Katalog-Eintrag (delivery = CATALOG),
+ *  - alle Seiten, die per `module_id` diesem Modul zugeordnet sind,
+ *  - die Modul-Version auf Flow-Ebene (für Cache-Invalidierung).
+ *
+ * Gibt `null` zurück, wenn das Modul nicht existiert.
+ */
+export const extractModuleArtifact = (flow: ListingFlow | null, moduleId: string): ListingFlow | null => {
+  if (!flow) return null;
+  const module = (flow.modules ?? []).find((m) => m.id === moduleId);
+  if (!module) return null;
+
+  const belongsToModule = (page: Page) => (page as any).module_id === moduleId;
+
+  const artifactModule: Module = { ...module, delivery: 'CATALOG' };
+
+  return {
+    id: moduleId,
+    'url-key': moduleId,
+    name: module.name?.de || module.name?.en || moduleId,
+    title: module.name ?? { de: moduleId, en: moduleId },
+    icon: module.icon ?? '',
+    version: module.version,
+    modules: [artifactModule],
+    pages_edit: (flow.pages_edit ?? []).filter(belongsToModule),
+    pages_view: (flow.pages_view ?? []).filter(belongsToModule),
+  };
+};
+
+/**
+ * Führt ein Modul-Artefakt in einen Basis-Flow zusammen:
+ *  - ergänzt fehlende Modul-Katalog-Einträge (vorhandene mit gleicher id bleiben unangetastet),
+ *  - hängt Seiten des Artefakts an, die im Basis-Flow noch nicht existieren (Abgleich über id).
+ *
+ * Immutable: liefert einen neuen Flow.
+ */
+export const mergeModuleArtifact = (flow: ListingFlow, artifact: ListingFlow): ListingFlow => {
+  const existingModuleIds = new Set((flow.modules ?? []).map((m) => m.id));
+  const mergedModules: Module[] = [
+    ...(flow.modules ?? []),
+    ...(artifact.modules ?? []).filter((m) => !existingModuleIds.has(m.id)),
+  ];
+
+  const existingEditIds = new Set((flow.pages_edit ?? []).map((p) => p.id));
+  const existingViewIds = new Set((flow.pages_view ?? []).map((p) => p.id));
+
+  return {
+    ...flow,
+    modules: mergedModules,
+    pages_edit: [
+      ...(flow.pages_edit ?? []),
+      ...(artifact.pages_edit ?? []).filter((p) => !existingEditIds.has(p.id)),
+    ],
+    pages_view: [
+      ...(flow.pages_view ?? []),
+      ...(artifact.pages_view ?? []).filter((p) => !existingViewIds.has(p.id)),
+    ],
+  };
+};


### PR DESCRIPTION
Schließt die „Modulare Flows"-Erweiterung ab: Authoring eigenständiger **CATALOG-Modul-Artefakte** plus letzte Politur.

## Was drin ist
- **CATALOG-Artefakte** (`src/utils/moduleArtifact.ts`):
  - `extractModuleArtifact(flow, moduleId)` — eigenständiges Artefakt (gleiches `ListingFlow`-Schema): Modul-Eintrag (`delivery: CATALOG`), Flow-`version`, modul-getaggte Seiten.
  - `mergeModuleArtifact(flow, artifact)` — Artefakt zurück in den Basis-Flow (Katalog + Seiten, dedupe über `id`).
  - Modul-Manager: pro Modul **„Als Artefakt exportieren"** (Download) + **„Artefakt importieren"** (Merge → `UPDATE_FLOW`).
- **Finalisierung**:
  - Modul-Badge auch an **Page-Tabs** (`PageTab`: Icon + Tooltip mit `module_id`).
  - `plans/modulare-flows-upgrade.md` mit Umsetzungsstand-Tabelle (Phasen abgehakt); `CLAUDE.md` auf den umgesetzten Stand gebracht.

## Topic
Feature

## Hinweis zur PR-Basis
Baut auf #5 (Phase 5) auf; Basis ist `claude/modulare-flows-phase5-validation`. GitHub retargetet automatisch auf `main`, sobald #5 gemergt ist. Der angezeigte Diff enthält nur die hier beschriebenen Änderungen.

## Testen
1. `npm install --legacy-peer-deps` → `npm start`.
2. Modul anlegen (`delivery` CATALOG, Version), Seite zuordnen → Page-Tab zeigt Modul-Icon (Tooltip = `module_id`).
3. **„Module"** → **„Als Artefakt exportieren"** → `<id>.json` enthält nur modul-getaggte Seiten + Modul-Eintrag + `version`.
4. **„Artefakt importieren"** in anderem Flow → Modul + Seiten ergänzt, kein Duplikat bei erneutem Import.

## Verifikation
`npm test` grün (104 Tests inkl. `moduleArtifact`/`moduleValidation`), `tsc --noEmit` ohne Fehler, `npm run build` erfolgreich.