### PR TITLE
Fix: „Module"-Button in der Toolbar sichtbar machen

### DIFF
--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -129,6 +129,11 @@ const Navigation: React.FC<NavigationProps> = ({
               variant="outlined"
               startIcon={<ModulesIcon />}
               onClick={onEditModules}
+              sx={{
+                color: 'white',
+                borderColor: 'rgba(255,255,255,0.7)',
+                '&:hover': { borderColor: 'white', bgcolor: 'rgba(255,255,255,0.12)' }
+              }}
             >
               Module
             </Button>


### PR DESCRIPTION
## Fix
Der **„Module"-Button** in der oberen Toolbar war als `outlined`-Button ohne explizite Farbe gerendert → Text/Icon erschienen in der Theme-Primärfarbe auf dem grünen AppBar und waren damit praktisch **unsichtbar**.

Jetzt: weißer Rahmen + weißer Text/Icon — sichtbar und als eigener Einstieg von den gefüllten Buttons unterscheidbar.

## Topic
Fix

## Testen
1. App öffnen (nach Deploy Hard-Reload).
2. In der oberen Leiste rechts neben „Workflow" ist der Button **„Module"** jetzt klar lesbar.

## Verifikation
`tsc --noEmit` ohne Fehler, `npm run build` erfolgreich.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2Pc4cAexeqUFrM1YonaJL)_