### PR TITLE
UX Phase 0: Einheitliches Feedback-System (Fundament)

### DIFF
--- a/plans/ux-overhaul.md
+++ b/plans/ux-overhaul.md
@@ -1,0 +1,67 @@
+# UX-Überarbeitung flow-ui-toolkit
+
+## Kontext
+
+Ziel: die gesamte UX des Toolkits von „funktional" zu „poliert & selbsterklärend" heben.
+Grundlage sind drei codebasierte UX-Reviews (App-Shell/Layout, Element-Erstellung/Editoren,
+Seiten/Module/Import-Export). Die Reviews waren rein code-basiert — eine ergänzende visuelle
+Usability-Runde sollte den Plan validieren.
+
+**Entscheidungen (mit Product Owner abgestimmt):**
+- **Desktop-first**: Der Toolkit bleibt ein Desktop-Authoring-Werkzeug. Responsives Layout (F4)
+  beschränkt sich auf „nicht kaputt / Tablet-tolerant" — kein voller Mobile-Umbau.
+- **Kompletter Mehr-Phasen-Umbau**, ein Branch/PR pro Phase.
+
+**Leitprinzip:** Erst Fundamente (Feedback-System, Theme-Tokens, Dialog-Basis), dann darauf
+aufsetzende Einzelfixes — sonst flickt man dieselben Probleme mehrfach.
+
+**Wiederverwenden statt neu bauen:** `EditorContext` (Undo/Redo, Multi-Select, Grouping),
+Editor-Factory-Muster, `AccordionSection`, `TabbedTranslatableFields`, `ElementPreview`,
+`IconField`, das neue `FeedbackContext`, die Snackbar-/Confirm-Muster.
+
+---
+
+## Phase 0 — Fundamente
+
+- [x] **F1 — Einheitliches Feedback-System** *(dieser PR)*
+  - `context/FeedbackContext.tsx`: `showSuccess/showError/showWarning/showInfo` + promise-basiertes `confirm()`; rendert eigene Snackbar + Confirm-Dialog.
+  - In `App.tsx` verdrahtet; die zwei ad-hoc Snackbars über Shims auf das System umgeleitet.
+  - `alert()`/`window.confirm()` ersetzt (`handleNew`, `handleOpen`, `handleSave`, Nesting-Regel).
+  - **Datenverlust-Schutz**: „Datei öffnen" fragt bei nicht-leerem Flow nach Bestätigung.
+  - **Bugfix**: stiller `catch` beim Modul-Artefakt-Import → Fehler-Toast + Validierung; Erfolgs-Toasts für Modul-CRUD/Import/Export.
+- [ ] **F2 — Theme-Tokens**: hardcodierte Farben (`#009F64`, `#43E77F`), Spacing, Font-Sizes in Theme-Tokens; Komponenten auf `primary.main` etc. umstellen. (`App.tsx` Theme, dann breit)
+- [ ] **F3 — Shared `DialogBase`**: einheitliche Titel/Actions, `fullScreen` auf Mobile, Fokus-Rückgabe, `aria`-Labels; Dialoge migrieren (`PageNavigator`, `WorkflowNameDialog`, Import/Export-Dialoge — `ModuleManagerDialog`/`EditPageDialog` haben fullScreen bereits).
+- [ ] **F4 — Desktop-first Layout-Toleranz** in `HybridEditor.tsx:35–69` (min-width + sauberer Umgang unterhalb der Breakpoints).
+
+## Phase 1 — Sicherheit & Korrektheit
+- [ ] Löschen mit Bestätigung für Elemente (`App.tsx handleRemoveElement`) — nutzt `confirm()`.
+- [ ] AJV-/Schema-Fehler inline sichtbar machen (`SchemaContext` + ungenutzte `ValidationHelper.tsx`).
+- [ ] Restliche `alert/confirm`-Reste in Dialogen auf Feedback-System umstellen.
+
+## Phase 2 — Orientierung & Navigation
+- [ ] „Auswählen" vs. „Drill-down" entkoppeln/visuell trennen; `selectedElementPath`↔`currentPath` vereinfachen (`HybridEditor.tsx`, `ElementHierarchyTree.tsx:362–387`).
+- [ ] Empty States + Erstkontakt-Onboarding (3-Spalten-Modell; leere Mitte mit CTA).
+- [ ] Accessibility: `aria-label`, Fokus-Management, Kontraste, semantische Landmarks, Keyboard-Shortcuts-Hilfe.
+
+## Phase 3 — Auffindbarkeit & Effizienz
+- [ ] Palette: Suche/Filter + Tooltips je Typ; Palette sichtbar im Layout (`ElementPalette.tsx`).
+- [ ] Drag&Drop: Drop-Indikatoren + Verschachtelungsregeln vorab (ungültiges Hinzufügen deaktivieren).
+- [ ] Multi-Select-Affordance (sichtbarer Toggle/Checkboxen).
+- [ ] Modul-Zuordnung immer sichtbar. *(INLINE/CATALOG- & Modul-Tooltips bereits via PR #8.)*
+
+## Phase 4 — Editor-Konsistenz & Wartbarkeit
+- [ ] `useElementUpdate`-Hook (dedupliziert Handler-Boilerplate über ~12 Editoren).
+- [ ] Listen-Editoren vereinheitlichen (ChipGroup-Dialog vs. SingleSelection-Tabelle).
+- [ ] Pflichtfeld-Markierung, Feld-ID prominenter, Hilfetexte, Duplikat-Optionen verhindern.
+
+## Phase 5 — Seiten & Flow-Metadaten
+- [ ] `pattern_type`-Auswahl bei Seitenanlage; Layout-Vorschau (`PageNavigator.tsx`, `EditPageDialog.tsx`).
+- [ ] Flow-Metadaten editierbar (id/url-key mit Validierung, Flow-Icon, Beschreibung); `related_pages` dokumentieren.
+
+---
+
+## Verifikation (je Phase)
+- `npm test` grün + `npm run build` (CI) ohne Fehler.
+- Neue Tests für Reducer-/Util-Änderungen (Muster: `EditorContext.test.tsx`).
+- Manuelle Klick-Checkliste je Phase.
+- Empfehlung: ergänzende visuelle Usability-Runde (Live-App), da Reviews code-basiert waren.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { CssBaseline, ThemeProvider, createTheme, Box, Snackbar, Alert } from '@mui/material';
+import { CssBaseline, ThemeProvider, createTheme, Box } from '@mui/material';
 import { v4 as uuidv4 } from 'uuid';
 import { generateUUID, transformFlowForExport } from './utils/uuidUtils';
 import styled from 'styled-components';
@@ -21,6 +21,7 @@ import { deepCloneElement } from './utils/deepCloneUtils';
 import { EditorProvider, useEditor, getElementByPath, getContainerType } from './context/EditorContext';
 import { logger } from './utils/logger';
 import { FieldValuesProvider } from './context/FieldValuesContext';
+import { FeedbackProvider, useFeedback } from './context/FeedbackContext';
 import { SchemaProvider } from './context/SchemaContext';
 import { SubflowProvider } from './context/SubflowContext';
 import { UserPreferencesProvider } from './context/UserPreferencesContext';
@@ -1634,11 +1635,13 @@ const AppContent: React.FC = () => {
   const [selectedElementPath, setSelectedElementPath] = useState<number[]>([]);
   const [showWorkflowNameDialog, setShowWorkflowNameDialog] = useState<boolean>(false);
   const [showModuleManager, setShowModuleManager] = useState<boolean>(false);
-  const [groupErrorSnackbar, setGroupErrorSnackbar] = useState<{ open: boolean; message: string }>({ open: false, message: '' });
+  const { showSuccess, showWarning, showError, confirm } = useFeedback();
+  // Shims auf das zentrale Feedback-System — halten die bestehenden Aufrufstellen kompatibel
+  const setGroupErrorSnackbar = (s: { open: boolean; message: string }) => { if (s.open) showWarning(s.message); };
+  const setSuccessSnackbar = (s: { open: boolean; message: string }) => { if (s.open) showSuccess(s.message); };
   // Copy/Export dialog state
   const [copyToPageDialogState, setCopyToPageDialogState] = useState<{ open: boolean; elementPath: number[] }>({ open: false, elementPath: [] });
   const [exportToFileDialogState, setExportToFileDialogState] = useState<{ open: boolean; elementPath: number[] }>({ open: false, elementPath: [] });
-  const [successSnackbar, setSuccessSnackbar] = useState<{ open: boolean; message: string }>({ open: false, message: '' });
 
   // Diese Funktion wurde durch handleSaveWorkflowName ersetzt
 
@@ -1761,7 +1764,7 @@ const AppContent: React.FC = () => {
         const { allowed, message } = isElementAllowedInParent(elementType, parentType);
 
         if (!allowed) {
-          alert(message);
+          showError(message);
           return;
         }
       }
@@ -2210,8 +2213,14 @@ const AppContent: React.FC = () => {
   };
 
   // Datei-Handler
-  const handleNew = () => {
-    if (window.confirm('Möchten Sie einen neuen Flow erstellen? Ungespeicherte Änderungen gehen verloren.')) {
+  const handleNew = async () => {
+    const ok = await confirm({
+      title: 'Neuen Flow erstellen?',
+      message: 'Ungespeicherte Änderungen gehen verloren.',
+      confirmLabel: 'Neu erstellen',
+      destructive: true,
+    });
+    if (ok) {
       dispatch({ type: 'SET_FLOW', flow: emptyFlow });
       setSelectedElementPath([]);
       // Die selectedPageId wird automatisch in der SET_FLOW Aktion gesetzt
@@ -2267,19 +2276,30 @@ const AppContent: React.FC = () => {
       const file = target.files?.[0];
       if (file) {
         const reader = new FileReader();
-        reader.onload = (event) => {
+        reader.onload = async (event) => {
           try {
             const json = JSON.parse(event.target?.result as string);
-            // Importiere die normalizeElementTypes-Funktion
-            import('./utils/normalizeUtils').then(({ normalizeElementTypes }) => {
-              // Normalisiere die Elementtypen, bevor der Flow gesetzt wird
-              const normalizedJson = normalizeElementTypes(json);
-              dispatch({ type: 'SET_FLOW', flow: normalizedJson });
-              setSelectedElementPath([]);
-              // Die selectedPageId wird automatisch in der SET_FLOW Aktion gesetzt
-            });
+            // Vor dem Ersetzen eines nicht-leeren Flows um Bestätigung bitten (Datenverlust-Schutz)
+            const hasContent = !!state.currentFlow &&
+              ((state.currentFlow.pages_edit?.length ?? 0) > 0 || (state.currentFlow.pages_view?.length ?? 0) > 0);
+            if (hasContent) {
+              const ok = await confirm({
+                title: 'Flow ersetzen?',
+                message: 'Der aktuelle Flow wird durch die geöffnete Datei ersetzt. Ungespeicherte Änderungen gehen verloren.',
+                confirmLabel: 'Ersetzen',
+                destructive: true,
+              });
+              if (!ok) return;
+            }
+            // Normalisiere die Elementtypen, bevor der Flow gesetzt wird
+            const { normalizeElementTypes } = await import('./utils/normalizeUtils');
+            const normalizedJson = normalizeElementTypes(json);
+            dispatch({ type: 'SET_FLOW', flow: normalizedJson });
+            setSelectedElementPath([]);
+            showSuccess('Flow erfolgreich geöffnet.');
+            // Die selectedPageId wird automatisch in der SET_FLOW Aktion gesetzt
           } catch (error) {
-            alert('Ungültiges JSON-Format: ' + error);
+            showError('Ungültiges JSON-Format: ' + error);
           }
         };
         reader.readAsText(file);
@@ -2292,7 +2312,7 @@ const AppContent: React.FC = () => {
     if (!state.currentFlow) return;
 
     // Importiere die Validierungsfunktion
-    import('./utils/fileElementValidator').then(({ validateAllFileUIElements }) => {
+    import('./utils/fileElementValidator').then(async ({ validateAllFileUIElements }) => {
       // Validiere alle FileUIElements in pages_edit
       const editValidationResults = validateAllFileUIElements(
         state.currentFlow!.pages_edit.flatMap(page => page.elements || [])
@@ -2324,7 +2344,7 @@ const AppContent: React.FC = () => {
           message += '\n⚠️ Die JSON-Datei kann im Zielsystem NICHT korrekt dargestellt werden!\n\n';
           message += 'Möchten Sie trotzdem fortfahren?';
 
-          if (!window.confirm(message)) {
+          if (!(await confirm({ title: 'Validierungsfehler', message, confirmLabel: 'Trotzdem fortfahren', destructive: true }))) {
             return;
           }
         } else if (warnings.length > 0) {
@@ -2338,7 +2358,7 @@ const AppContent: React.FC = () => {
           });
           message += '\nMöchten Sie trotzdem fortfahren?';
 
-          if (!window.confirm(message)) {
+          if (!(await confirm({ title: 'Warnungen', message, confirmLabel: 'Trotzdem fortfahren' }))) {
             return;
           }
         }
@@ -2496,23 +2516,6 @@ const AppContent: React.FC = () => {
         </Box>
       )}
       */}
-      {/* Snackbar für Gruppierungs-Fehlermeldungen */}
-      <Snackbar
-        open={groupErrorSnackbar.open}
-        autoHideDuration={5000}
-        onClose={() => setGroupErrorSnackbar({ open: false, message: '' })}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      >
-        <Alert
-          onClose={() => setGroupErrorSnackbar({ open: false, message: '' })}
-          severity="warning"
-          variant="filled"
-          sx={{ width: '100%' }}
-        >
-          {groupErrorSnackbar.message}
-        </Alert>
-      </Snackbar>
-
       {/* Copy to Page Dialog */}
       <CopyElementToPageDialog
         open={copyToPageDialogState.open}
@@ -2549,22 +2552,6 @@ const AppContent: React.FC = () => {
         }
       />
 
-      {/* Snackbar für Erfolgsmeldungen (allgemein) */}
-      <Snackbar
-        open={successSnackbar.open}
-        autoHideDuration={4000}
-        onClose={() => setSuccessSnackbar({ open: false, message: '' })}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      >
-        <Alert
-          onClose={() => setSuccessSnackbar({ open: false, message: '' })}
-          severity="success"
-          variant="filled"
-          sx={{ width: '100%' }}
-        >
-          {successSnackbar.message}
-        </Alert>
-      </Snackbar>
     </AppContainer>
     </FieldValuesProvider>
   );
@@ -2578,7 +2565,9 @@ const App: React.FC = () => {
         <EditorProvider>
           <SubflowProvider>
             <UserPreferencesProvider>
-              <AppContent />
+              <FeedbackProvider>
+                <AppContent />
+              </FeedbackProvider>
             </UserPreferencesProvider>
           </SubflowProvider>
         </EditorProvider>

--- a/src/components/ModuleManager/ModuleManagerDialog.tsx
+++ b/src/components/ModuleManager/ModuleManagerDialog.tsx
@@ -36,6 +36,7 @@ import { getIconPath } from '../../utils/mdiIcons';
 import { TabbedTranslatableFields } from '../PropertyEditor/common/TabbedTranslatableFields';
 import IconField from '../PropertyEditor/common/IconField';
 import { useEditor } from '../../context/EditorContext';
+import { useFeedback } from '../../context/FeedbackContext';
 import { Module, ListingFlow } from '../../models/listingFlow';
 import { danglingModuleIds } from '../../utils/moduleValidation';
 import { extractModuleArtifact, mergeModuleArtifact } from '../../utils/moduleArtifact';
@@ -94,6 +95,7 @@ const ModuleManagerDialog: React.FC<ModuleManagerDialogProps> = ({ open, onClose
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
   const { state, dispatch } = useEditor();
+  const { showSuccess, showError } = useFeedback();
 
   const modules = state.currentFlow?.modules ?? [];
   const dangling = danglingModuleIds(state.currentFlow);
@@ -138,11 +140,14 @@ const ModuleManagerDialog: React.FC<ModuleManagerDialogProps> = ({ open, onClose
       dispatch({ type: 'UPDATE_MODULE', moduleId: editingId, updates: moduleToSave });
     }
     setEditorOpen(false);
+    showSuccess(`Modul „${moduleToSave.id}" gespeichert.`);
   };
 
   const handleConfirmDelete = () => {
     if (confirmDeleteId) {
-      dispatch({ type: 'REMOVE_MODULE', moduleId: confirmDeleteId });
+      const deletedId = confirmDeleteId;
+      dispatch({ type: 'REMOVE_MODULE', moduleId: deletedId });
+      showSuccess(`Modul „${deletedId}" gelöscht.`);
     }
     setConfirmDeleteId(null);
   };
@@ -150,7 +155,10 @@ const ModuleManagerDialog: React.FC<ModuleManagerDialogProps> = ({ open, onClose
   // Exportiert ein Modul als eigenständiges CATALOG-Artefakt (flow-förmige JSON).
   const handleExportArtifact = (moduleId: string) => {
     const artifact = extractModuleArtifact(state.currentFlow, moduleId);
-    if (!artifact) return;
+    if (!artifact) {
+      showError(`Modul „${moduleId}" konnte nicht als Artefakt exportiert werden.`);
+      return;
+    }
     const json = JSON.stringify(transformFlowForExport(artifact), null, 2);
     const blob = new Blob([json], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
@@ -161,6 +169,7 @@ const ModuleManagerDialog: React.FC<ModuleManagerDialogProps> = ({ open, onClose
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
+    showSuccess(`Modul „${moduleId}" als Artefakt exportiert.`);
   };
 
   // Importiert ein Modul-Artefakt und führt es in den aktuellen Flow zusammen.
@@ -176,10 +185,14 @@ const ModuleManagerDialog: React.FC<ModuleManagerDialogProps> = ({ open, onClose
       reader.onload = (event) => {
         try {
           const artifact = JSON.parse(event.target?.result as string) as ListingFlow;
+          if (!artifact || !Array.isArray(artifact.modules) || artifact.modules.length === 0) {
+            throw new Error('Datei enthält keinen Modul-Katalog (modules[]).');
+          }
           const merged = mergeModuleArtifact(state.currentFlow!, artifact);
           dispatch({ type: 'UPDATE_FLOW', flow: merged });
-        } catch {
-          // Ungültige Datei – still ignorieren (Fehleranzeige erfolgt über bestehende Mechanismen)
+          showSuccess(`Modul-Artefakt „${artifact.modules[0].id}" importiert.`);
+        } catch (err) {
+          showError('Artefakt konnte nicht importiert werden: ' + (err instanceof Error ? err.message : 'ungültige Datei'));
         }
       };
       reader.readAsText(file);

--- a/src/context/FeedbackContext.tsx
+++ b/src/context/FeedbackContext.tsx
@@ -1,0 +1,117 @@
+import React, { createContext, useCallback, useContext, useRef, useState } from 'react';
+import {
+  Alert,
+  AlertColor,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Snackbar,
+} from '@mui/material';
+
+/**
+ * Zentrales Feedback-System: vereinheitlicht Erfolg-/Fehler-/Warn-Toasts und
+ * Bestätigungsdialoge an einer Stelle. Ersetzt verstreute `alert()`/`window.confirm()`
+ * und doppelte ad-hoc Snackbars. Komponenten nutzen `useFeedback()`.
+ */
+export interface ConfirmOptions {
+  title?: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Färbt die Bestätigen-Schaltfläche rot (für löschende/überschreibende Aktionen). */
+  destructive?: boolean;
+}
+
+interface FeedbackContextValue {
+  showSuccess: (message: string) => void;
+  showError: (message: string) => void;
+  showWarning: (message: string) => void;
+  showInfo: (message: string) => void;
+  /** Promise-basierter Ersatz für window.confirm — löst zu true (bestätigt) / false (abgebrochen). */
+  confirm: (options: ConfirmOptions) => Promise<boolean>;
+}
+
+const FeedbackContext = createContext<FeedbackContextValue | undefined>(undefined);
+
+export const useFeedback = (): FeedbackContextValue => {
+  const ctx = useContext(FeedbackContext);
+  if (!ctx) {
+    throw new Error('useFeedback muss innerhalb eines FeedbackProvider verwendet werden');
+  }
+  return ctx;
+};
+
+interface ToastState {
+  open: boolean;
+  message: string;
+  severity: AlertColor;
+}
+
+export const FeedbackProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [toast, setToast] = useState<ToastState>({ open: false, message: '', severity: 'success' });
+  const [confirmState, setConfirmState] = useState<(ConfirmOptions & { open: boolean }) | null>(null);
+  const resolverRef = useRef<((value: boolean) => void) | null>(null);
+
+  const showSuccess = useCallback((message: string) => setToast({ open: true, message, severity: 'success' }), []);
+  const showError = useCallback((message: string) => setToast({ open: true, message, severity: 'error' }), []);
+  const showWarning = useCallback((message: string) => setToast({ open: true, message, severity: 'warning' }), []);
+  const showInfo = useCallback((message: string) => setToast({ open: true, message, severity: 'info' }), []);
+
+  const confirm = useCallback((options: ConfirmOptions) => {
+    return new Promise<boolean>((resolve) => {
+      resolverRef.current = resolve;
+      setConfirmState({ ...options, open: true });
+    });
+  }, []);
+
+  const closeConfirm = useCallback((result: boolean) => {
+    if (resolverRef.current) {
+      resolverRef.current(result);
+      resolverRef.current = null;
+    }
+    setConfirmState((prev) => (prev ? { ...prev, open: false } : null));
+  }, []);
+
+  const closeToast = useCallback((_event?: unknown, reason?: string) => {
+    if (reason === 'clickaway') return;
+    setToast((prev) => ({ ...prev, open: false }));
+  }, []);
+
+  return (
+    <FeedbackContext.Provider value={{ showSuccess, showError, showWarning, showInfo, confirm }}>
+      {children}
+
+      <Snackbar
+        open={toast.open}
+        autoHideDuration={toast.severity === 'error' ? 8000 : 4000}
+        onClose={closeToast}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={() => closeToast()} severity={toast.severity} variant="filled" sx={{ width: '100%' }}>
+          {toast.message}
+        </Alert>
+      </Snackbar>
+
+      <Dialog open={!!confirmState?.open} onClose={() => closeConfirm(false)} maxWidth="xs" fullWidth>
+        {confirmState?.title && <DialogTitle>{confirmState.title}</DialogTitle>}
+        <DialogContent>
+          <DialogContentText sx={{ whiteSpace: 'pre-line' }}>{confirmState?.message}</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => closeConfirm(false)}>{confirmState?.cancelLabel || 'Abbrechen'}</Button>
+          <Button
+            onClick={() => closeConfirm(true)}
+            variant="contained"
+            color={confirmState?.destructive ? 'error' : 'primary'}
+            autoFocus
+          >
+            {confirmState?.confirmLabel || 'Bestätigen'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </FeedbackContext.Provider>
+  );
+};


### PR DESCRIPTION
Auftakt der UX-Überarbeitung: ein zentrales Feedback-System als Fundament (Phasen 1 & 3 bauen darauf auf) — plus ein echter Bugfix beim Modul-Artefakt-Import.

## Kernlogik
- **`context/FeedbackContext.tsx`** (neu): `showSuccess/showError/showWarning/showInfo` (Toasts) + promise-basiertes `confirm()`; rendert eigene Snackbar + Bestätigungsdialog. Ersetzt verstreute `alert()`/`window.confirm()` und doppelte Ad-hoc-Snackbars.
- **`App.tsx`**: `alert()`/`window.confirm()` durchgängig auf das System umgestellt; die zwei bestehenden Snackbars über schlanke Shims umgeleitet (14 Aufrufstellen unverändert → ein einheitliches System).
- **Datenverlust-Schutz**: „Datei öffnen" fragt bei nicht-leerem Flow vor dem Ersetzen nach Bestätigung; Erfolgs-Toast nach dem Öffnen.
- **Bugfix**: stiller `catch` beim Modul-Artefakt-Import schluckte Fehler → jetzt Fehler-Toast + Artefakt-Validierung (`modules[]`); zusätzlich Erfolgs-Toasts für Modul-Anlegen/Bearbeiten/Löschen/Import/Export.
- **`plans/ux-overhaul.md`** (neu): lebender Mehr-Phasen-Plan (Desktop-first), Phase 0 F1 abgehakt.

## Labels
Website (doorbit-new) trifft nicht zu — Repo ist flow-ui-toolkit. Topic: **Feature** + **Fix**.

## Testen
1. „Neu"/„Öffnen" bei vorhandenem Flow → Bestätigungsdialog erscheint (Abbrechen lässt Flow unverändert).
2. Eine kaputte/leere JSON als Modul-Artefakt importieren → roter Fehler-Toast statt stillem Nichts.
3. Modul anlegen/löschen/exportieren → grüner Erfolgs-Toast.
4. Ungültige Flow-Datei öffnen → Fehler-Toast „Ungültiges JSON-Format".

## Verifikation
`tsc --noEmit` ohne Fehler, `npm test` grün (100), `npm run build` (CI) erfolgreich (Bundle −321 B).

## Hinweis
Reviews waren code-basiert (kein Live-Klicken) — eine kurze visuelle Runde wird empfohlen. Restliche Phase-0-Fundamente (Theme-Tokens, DialogBase, Layout-Toleranz) folgen als nächste PRs, sobald dieses Fundament reviewt ist.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2Pc4cAexeqUFrM1YonaJL)_