### PR TITLE
UX: Tastaturkürzel-Hilfe + Confirm-Konsolidierung

### DIFF
--- a/plans/ux-overhaul.md
+++ b/plans/ux-overhaul.md
@@ -34,14 +34,16 @@ Editor-Factory-Muster, `AccordionSection`, `TabbedTranslatableFields`, `ElementP
 - [x] **F4 — Desktop-first Layout-Toleranz** *(PR #10)*: `HybridEditor` nutzt Flex + Mindestbreiten; bei schmalen Viewports horizontal scrollen statt Spalten unbrauchbar quetschen.
 
 ## Phase 1 — Sicherheit & Korrektheit
-- [ ] Löschen mit Bestätigung für Elemente (`App.tsx handleRemoveElement`) — nutzt `confirm()`.
-- [ ] AJV-/Schema-Fehler inline sichtbar machen (`SchemaContext` + ungenutzte `ValidationHelper.tsx`).
-- [ ] Restliche `alert/confirm`-Reste in Dialogen auf Feedback-System umstellen.
+- [x] Löschen mit Bestätigung — **war bereits vorhanden** (Element via `ElementContextView`, Seite, Modul). Befund der Review-Agenten war ungenau.
+- [x] **Confirm-Konsolidierung** *(PR #11)*: Seiten- & Modul-Lösch-Dialoge auf das einheitliche `confirm()` umgestellt; „letzte Seite"-Sperre gibt jetzt Feedback. ElementContextView **bewusst aufgeschoben** (1087-Zeilen-Datei, bestehender Dialog gut inkl. Kind-Warnung).
+- [~] AJV-/Schema-Fehler inline: **blockiert** — `SchemaContext`-Schema ist eine unvollständige Teilmenge (fehlende Typen: String, Table, KeyValueList, ImageGallery, FieldText) → würde gültige Flows fälschlich als ungültig melden. Voraussetzung: Schema zuerst ans volle Modell angleichen (eigene Aufgabe, Schema-Sync-Regel).
+- [x] Restliche `alert/confirm`-Reste auf Feedback-System — erledigt mit F1 (#9).
 
 ## Phase 2 — Orientierung & Navigation
 - [ ] „Auswählen" vs. „Drill-down" entkoppeln/visuell trennen; `selectedElementPath`↔`currentPath` vereinfachen (`HybridEditor.tsx`, `ElementHierarchyTree.tsx:362–387`).
 - [ ] Empty States + Erstkontakt-Onboarding (3-Spalten-Modell; leere Mitte mit CTA).
-- [ ] Accessibility: `aria-label`, Fokus-Management, Kontraste, semantische Landmarks, Keyboard-Shortcuts-Hilfe.
+- [ ] Accessibility: `aria-label`, Fokus-Management, Kontraste, semantische Landmarks.
+- [x] **Keyboard-Shortcuts-Hilfe** *(PR #11)*: Dialog (via DialogBase) listet die vorhandenen, bislang undokumentierten Shortcuts (Strg+Z/Y/S, Esc); Tastatur-Icon in der Toolbar.
 
 ## Phase 3 — Auffindbarkeit & Effizienz
 - [ ] Palette: Suche/Filter + Tooltips je Typ; Palette sichtbar im Layout (`ElementPalette.tsx`).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { EditorProvider, useEditor, getElementByPath, getContainerType } from '.
 import { logger } from './utils/logger';
 import { FieldValuesProvider } from './context/FieldValuesContext';
 import { FeedbackProvider, useFeedback } from './context/FeedbackContext';
+import KeyboardShortcutsDialog from './components/HybridEditor/KeyboardShortcutsDialog';
 import { SchemaProvider } from './context/SchemaContext';
 import { SubflowProvider } from './context/SubflowContext';
 import { UserPreferencesProvider } from './context/UserPreferencesContext';
@@ -1635,6 +1636,7 @@ const AppContent: React.FC = () => {
   const [selectedElementPath, setSelectedElementPath] = useState<number[]>([]);
   const [showWorkflowNameDialog, setShowWorkflowNameDialog] = useState<boolean>(false);
   const [showModuleManager, setShowModuleManager] = useState<boolean>(false);
+  const [showShortcuts, setShowShortcuts] = useState<boolean>(false);
   const { showSuccess, showWarning, showError, confirm } = useFeedback();
   // Shims auf das zentrale Feedback-System — halten die bestehenden Aufrufstellen kompatibel
   const setGroupErrorSnackbar = (s: { open: boolean; message: string }) => { if (s.open) showWarning(s.message); };
@@ -2402,8 +2404,11 @@ const AppContent: React.FC = () => {
           onEditWorkflowName={handleEditWorkflowName}
           onEditModules={() => setShowModuleManager(true)}
           onOpenDocumentation={handleOpenDocumentation}
+          onShowShortcuts={() => setShowShortcuts(true)}
           workflowName={state.currentFlow?.name || "Workflow"}
         />
+
+        <KeyboardShortcutsDialog open={showShortcuts} onClose={() => setShowShortcuts(false)} />
 
         {/* Workflow-Namen-Dialog */}
         <WorkflowNameDialog

--- a/src/components/HybridEditor/KeyboardShortcutsDialog.tsx
+++ b/src/components/HybridEditor/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import DialogBase from '../common/DialogBase';
+
+interface KeyboardShortcutsDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface Shortcut {
+  keys: string[];
+  description: string;
+}
+
+const SHORTCUTS: Shortcut[] = [
+  { keys: ['Strg', 'Z'], description: 'Rückgängig' },
+  { keys: ['Strg', 'Y'], description: 'Wiederherstellen' },
+  { keys: ['Strg', 'S'], description: 'Als Datei speichern' },
+  { keys: ['Esc'], description: 'Mehrfachauswahl-Modus beenden' },
+];
+
+const KeyCap: React.FC<{ label: string }> = ({ label }) => (
+  <Box
+    component="kbd"
+    sx={{
+      display: 'inline-block',
+      minWidth: 24,
+      px: 1,
+      py: 0.25,
+      textAlign: 'center',
+      fontFamily: 'inherit',
+      fontSize: '0.8rem',
+      lineHeight: 1.6,
+      color: 'text.primary',
+      backgroundColor: 'grey.100',
+      border: '1px solid',
+      borderColor: 'grey.400',
+      borderRadius: 1,
+      boxShadow: 'inset 0 -1px 0 rgba(0,0,0,0.15)',
+    }}
+  >
+    {label}
+  </Box>
+);
+
+/**
+ * Listet die verfügbaren Tastaturkürzel des Editors auf. Die Kürzel sind in
+ * App.tsx (globaler keydown-Handler) implementiert; dieser Dialog macht sie
+ * auffindbar (sie waren bislang undokumentiert).
+ */
+const KeyboardShortcutsDialog: React.FC<KeyboardShortcutsDialogProps> = ({ open, onClose }) => {
+  return (
+    <DialogBase
+      open={open}
+      onClose={onClose}
+      title="Tastaturkürzel"
+      maxWidth="xs"
+      onConfirm={onClose}
+      confirmLabel="Schließen"
+      hideCancel
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, pt: 0.5 }}>
+        {SHORTCUTS.map((sc) => (
+          <Box
+            key={sc.description}
+            sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2 }}
+          >
+            <Typography variant="body2">{sc.description}</Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexShrink: 0 }}>
+              {sc.keys.map((key, i) => (
+                <React.Fragment key={key}>
+                  {i > 0 && <Typography variant="caption" sx={{ color: 'text.secondary' }}>+</Typography>}
+                  <KeyCap label={key} />
+                </React.Fragment>
+              ))}
+            </Box>
+          </Box>
+        ))}
+      </Box>
+      <Typography variant="caption" sx={{ display: 'block', mt: 2, color: 'text.secondary' }}>
+        Kürzel greifen nicht, während ein Eingabefeld fokussiert ist.
+      </Typography>
+    </DialogBase>
+  );
+};
+
+export default KeyboardShortcutsDialog;

--- a/src/components/ModuleManager/ModuleManagerDialog.tsx
+++ b/src/components/ModuleManager/ModuleManagerDialog.tsx
@@ -95,7 +95,7 @@ const ModuleManagerDialog: React.FC<ModuleManagerDialogProps> = ({ open, onClose
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
   const { state, dispatch } = useEditor();
-  const { showSuccess, showError } = useFeedback();
+  const { showSuccess, showError, confirm } = useFeedback();
 
   const modules = state.currentFlow?.modules ?? [];
   const dangling = danglingModuleIds(state.currentFlow);
@@ -106,8 +106,6 @@ const ModuleManagerDialog: React.FC<ModuleManagerDialogProps> = ({ open, onClose
   const [editModule, setEditModule] = useState<Module>(emptyModule());
   const [languageTab, setLanguageTab] = useState(0);
 
-  // Lösch-Bestätigung
-  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
   const handleOpenAdd = () => {
     setEditingId(null);
@@ -143,13 +141,17 @@ const ModuleManagerDialog: React.FC<ModuleManagerDialogProps> = ({ open, onClose
     showSuccess(`Modul „${moduleToSave.id}" gespeichert.`);
   };
 
-  const handleConfirmDelete = () => {
-    if (confirmDeleteId) {
-      const deletedId = confirmDeleteId;
-      dispatch({ type: 'REMOVE_MODULE', moduleId: deletedId });
-      showSuccess(`Modul „${deletedId}" gelöscht.`);
+  const handleDeleteModule = async (moduleId: string) => {
+    const ok = await confirm({
+      title: 'Modul löschen?',
+      message: 'Das Modul wird aus dem Katalog entfernt. Bestehende Zuordnungen (module_id) an Seiten und Elementen werden dabei gelöst — die betroffenen Inhalte bleiben erhalten und sind wieder modul-unabhängig sichtbar.',
+      confirmLabel: 'Löschen',
+      destructive: true,
+    });
+    if (ok) {
+      dispatch({ type: 'REMOVE_MODULE', moduleId });
+      showSuccess(`Modul „${moduleId}" gelöscht.`);
     }
-    setConfirmDeleteId(null);
   };
 
   // Exportiert ein Modul als eigenständiges CATALOG-Artefakt (flow-förmige JSON).
@@ -289,7 +291,7 @@ const ModuleManagerDialog: React.FC<ModuleManagerDialogProps> = ({ open, onClose
                         <IconButton
                           size="small"
                           color="error"
-                          onClick={() => setConfirmDeleteId(module.id)}
+                          onClick={() => handleDeleteModule(module.id)}
                           aria-label="Löschen"
                         >
                           <DeleteIcon fontSize="small" />
@@ -427,23 +429,6 @@ const ModuleManagerDialog: React.FC<ModuleManagerDialogProps> = ({ open, onClose
         </DialogActions>
       </Dialog>
 
-      {/* Lösch-Bestätigung */}
-      <Dialog open={confirmDeleteId !== null} onClose={() => setConfirmDeleteId(null)} maxWidth="xs" fullWidth>
-        <DialogTitle>Modul löschen?</DialogTitle>
-        <DialogContent>
-          <Typography variant="body2">
-            Das Modul wird aus dem Katalog entfernt. Bestehende Zuordnungen (module_id) an Seiten und
-            Elementen werden dabei gelöst — die betroffenen Inhalte bleiben erhalten und sind wieder
-            modul-unabhängig sichtbar.
-          </Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setConfirmDeleteId(null)}>Abbrechen</Button>
-          <Button onClick={handleConfirmDelete} variant="contained" color="error">
-            Löschen
-          </Button>
-        </DialogActions>
-      </Dialog>
     </>
   );
 };

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -9,7 +9,8 @@ import {
   Redo as RedoIcon,
   Edit as EditIcon,
   Extension as ModulesIcon,
-  HelpOutline as HelpIcon
+  HelpOutline as HelpIcon,
+  KeyboardOutlined as KeyboardIcon
 } from '@mui/icons-material';
 
 interface NavigationProps {
@@ -23,6 +24,7 @@ interface NavigationProps {
   onEditWorkflowName: () => void;
   onEditModules: () => void;
   onOpenDocumentation?: () => void;
+  onShowShortcuts?: () => void;
   workflowName: string;
 }
 
@@ -60,6 +62,7 @@ const Navigation: React.FC<NavigationProps> = ({
   onEditWorkflowName,
   onEditModules,
   onOpenDocumentation,
+  onShowShortcuts,
   workflowName
 }) => {
   return (
@@ -142,6 +145,22 @@ const Navigation: React.FC<NavigationProps> = ({
         </Box>
 
         <RightActions>
+          {onShowShortcuts && (
+            <Tooltip title="Tastaturkürzel">
+              <IconButton
+                onClick={onShowShortcuts}
+                size="large"
+                aria-label="Tastaturkürzel anzeigen"
+                sx={{
+                  bgcolor: '#009F64',
+                  color: 'white',
+                  '&:hover': { bgcolor: '#008D58' }
+                }}
+              >
+                <KeyboardIcon />
+              </IconButton>
+            </Tooltip>
+          )}
           {onOpenDocumentation && (
             <Tooltip title="Dokumentation öffnen">
               <span>

--- a/src/components/PageNavigator/PageNavigator.tsx
+++ b/src/components/PageNavigator/PageNavigator.tsx
@@ -22,6 +22,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Page } from '../../models/listingFlow';
 import { useEditor } from '../../context/EditorContext';
 import { useFieldValues } from '../../context/FieldValuesContext';
+import { useFeedback } from '../../context/FeedbackContext';
 import { evaluateVisibilityCondition } from '../../utils/visibilityUtils';
 import PageTab from './PageTab';
 import EditPageDialog from './EditPageDialog';
@@ -35,10 +36,9 @@ interface PageNavigatorProps {
 const PageNavigator: React.FC<PageNavigatorProps> = ({ pages, selectedPageId }) => {
   const { dispatch, state } = useEditor();
   const { fieldValues } = useFieldValues();
+  const { confirm, showWarning } = useFeedback();
   const [openNewPageDialog, setOpenNewPageDialog] = React.useState(false);
   const [newPageTitle, setNewPageTitle] = React.useState('');
-  const [deleteConfirmOpen, setDeleteConfirmOpen] = React.useState(false);
-  const [pageToDelete, setPageToDelete] = React.useState<string | null>(null);
   const [editPageDialogOpen, setEditPageDialogOpen] = React.useState(false);
   const [pageToEdit, setPageToEdit] = React.useState<Page | null>(null);
   const [importDialogOpen, setImportDialogOpen] = React.useState(false);
@@ -93,14 +93,6 @@ const PageNavigator: React.FC<PageNavigatorProps> = ({ pages, selectedPageId }) 
     setImportSuccessMessage(`${editPages.length} Seite(n) erfolgreich importiert.`);
   }, [dispatch]);
 
-  const handleConfirmDelete = () => {
-    if (pageToDelete) {
-      dispatch({ type: 'REMOVE_PAGE', pageId: pageToDelete });
-      setDeleteConfirmOpen(false);
-      setPageToDelete(null);
-    }
-  };
-
   // Handler für Seitenklick für den direkten Tab-Klick
   const handleTabClick = useCallback((pageId: string) => {
     dispatch({ type: 'SELECT_PAGE', pageId });
@@ -111,16 +103,20 @@ const PageNavigator: React.FC<PageNavigatorProps> = ({ pages, selectedPageId }) 
     dispatch({ type: 'MOVE_PAGE', sourceIndex: dragIndex, targetIndex: hoverIndex });
   }, [dispatch]);
 
-  const handleCancelDelete = () => {
-    setDeleteConfirmOpen(false);
-    setPageToDelete(null);
-  };
-
   // Handler für Löschen einer Seite
-  const handleDeletePage = (pageId: string) => {
-    if (pages.length > 1) {
-      setPageToDelete(pageId);
-      setDeleteConfirmOpen(true);
+  const handleDeletePage = async (pageId: string) => {
+    if (pages.length <= 1) {
+      showWarning('Die letzte Seite kann nicht gelöscht werden.');
+      return;
+    }
+    const ok = await confirm({
+      title: 'Seite löschen?',
+      message: 'Alle Elemente auf dieser Seite werden gelöscht.',
+      confirmLabel: 'Löschen',
+      destructive: true,
+    });
+    if (ok) {
+      dispatch({ type: 'REMOVE_PAGE', pageId });
     }
   };
 
@@ -295,20 +291,6 @@ const PageNavigator: React.FC<PageNavigatorProps> = ({ pages, selectedPageId }) 
         <DialogActions>
           <Button onClick={handleCloseNewPageDialog}>Abbrechen</Button>
           <Button onClick={handleCreateNewPage} variant="contained">Erstellen</Button>
-        </DialogActions>
-      </Dialog>
-
-      {/* Dialog für Seite löschen */}
-      <Dialog open={deleteConfirmOpen} onClose={handleCancelDelete}>
-        <DialogTitle>Seite löschen</DialogTitle>
-        <DialogContent>
-          <Typography>
-            Sind Sie sicher, dass Sie diese Seite löschen möchten? Alle Elemente auf dieser Seite werden gelöscht.
-          </Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCancelDelete}>Abbrechen</Button>
-          <Button onClick={handleConfirmDelete} color="error" variant="contained">Löschen</Button>
         </DialogActions>
       </Dialog>
 


### PR DESCRIPTION
**Gestapelt auf #10** (das wiederum auf #9). Reihenfolge zum Mergen: #9 → #10 → #11; GitHub retargetet danach automatisch.

## Kernlogik
- **Tastaturkürzel-Hilfe** (`KeyboardShortcutsDialog`, via DialogBase): listet die **bereits vorhandenen, aber undokumentierten** Shortcuts (Strg+Z Rückgängig, Strg+Y Wiederherstellen, Strg+S Speichern, Esc Auswahl beenden). Erreichbar über ein neues Tastatur-Icon in der Toolbar.
- **Confirm-Konsolidierung**: die bespoke Lösch-Dialoge von **Seiten** (`PageNavigator`) und **Modulen** (`ModuleManagerDialog`) laufen jetzt über das einheitliche `confirm()` aus dem Feedback-System (#9). Die „letzte Seite kann nicht gelöscht werden"-Sperre gibt jetzt **sichtbares Feedback** statt stillem Nichts.

## Wichtige Befunde (während der Umsetzung)
- **Löschen hatte bereits überall eine Bestätigung** (Element/Seite/Modul) — der „kein Confirm"-Befund der Review war ungenau; kein neuer Dialog nötig.
- **Inline-AJV-Validierung ist blockiert**: das `SchemaContext`-Schema ist eine unvollständige Teilmenge (fehlende Typen: String, Table, KeyValueList, ImageGallery, FieldText) → würde gültige Flows fälschlich als ungültig melden. Sauber wäre, das Schema zuerst ans volle Modell anzugleichen (eigene Aufgabe).
- **ElementContextView-Lösch-Dialog bewusst belassen**: 1087-Zeilen-Datei, bestehender Dialog ist bereits gut (inkl. Kind-Element-Warnung) — Konsolidierung dort hätte unverhältnismäßiges Regressionsrisiko.

## Topic
Feature / Refactoring

## Testen
1. Toolbar → Tastatur-Icon → Dialog mit Shortcuts erscheint.
2. Seite löschen → einheitlicher Bestätigungsdialog (roter „Löschen"-Button); bei nur einer Seite → Warn-Toast.
3. Modul löschen → einheitlicher Bestätigungsdialog.

## Verifikation
`tsc --noEmit` ok, `npm test` grün (100), `npm run build` (CI) erfolgreich.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2Pc4cAexeqUFrM1YonaJL)_