### PR TITLE
UX Phase 2: Erstkontakt-Onboarding + Spalten-Landmarks

### DIFF
--- a/plans/ux-overhaul.md
+++ b/plans/ux-overhaul.md
@@ -41,8 +41,8 @@ Editor-Factory-Muster, `AccordionSection`, `TabbedTranslatableFields`, `ElementP
 
 ## Phase 2 — Orientierung & Navigation
 - [ ] „Auswählen" vs. „Drill-down" entkoppeln/visuell trennen; `selectedElementPath`↔`currentPath` vereinfachen (`HybridEditor.tsx`, `ElementHierarchyTree.tsx:362–387`).
-- [ ] Empty States + Erstkontakt-Onboarding (3-Spalten-Modell; leere Mitte mit CTA).
-- [ ] Accessibility: `aria-label`, Fokus-Management, Kontraste, semantische Landmarks.
+- [x] **Empty States + Erstkontakt-Onboarding** *(PR Phase 2)*: `OnboardingDialog` (via DialogBase) erklärt das 3-Spalten-Modell + Grundablauf; First-Run automatisch (localStorage `flowToolkit.onboardingSeen`), jederzeit über Toolbar-Icon „Erste Schritte" erneut aufrufbar. Leere Mitte mit CTA war bereits vorhanden.
+- [~] Accessibility: 3 Spalten als Landmarks (`role="region"` + `aria-label`) **erledigt** *(PR Phase 2)*; Fokus-Management/Kontraste/weitere Landmarks weiterhin offen.
 - [x] **Keyboard-Shortcuts-Hilfe** *(PR #11)*: Dialog (via DialogBase) listet die vorhandenen, bislang undokumentierten Shortcuts (Strg+Z/Y/S, Esc); Tastatur-Icon in der Toolbar.
 
 ## Phase 3 — Auffindbarkeit & Effizienz

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { FieldValuesProvider } from './context/FieldValuesContext';
 import { FeedbackProvider, useFeedback } from './context/FeedbackContext';
 import KeyboardShortcutsDialog from './components/HybridEditor/KeyboardShortcutsDialog';
 import ValidationStatus from './components/common/ValidationStatus';
+import OnboardingDialog from './components/common/OnboardingDialog';
 import { SchemaProvider } from './context/SchemaContext';
 import { SubflowProvider } from './context/SubflowContext';
 import { UserPreferencesProvider } from './context/UserPreferencesContext';
@@ -1638,6 +1639,22 @@ const AppContent: React.FC = () => {
   const [showWorkflowNameDialog, setShowWorkflowNameDialog] = useState<boolean>(false);
   const [showModuleManager, setShowModuleManager] = useState<boolean>(false);
   const [showShortcuts, setShowShortcuts] = useState<boolean>(false);
+  // Erstkontakt-Onboarding: beim ersten Start automatisch zeigen (einmalig via localStorage).
+  const [showOnboarding, setShowOnboarding] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem('flowToolkit.onboardingSeen') !== 'true';
+    } catch {
+      return false;
+    }
+  });
+  const closeOnboarding = () => {
+    setShowOnboarding(false);
+    try {
+      localStorage.setItem('flowToolkit.onboardingSeen', 'true');
+    } catch {
+      /* localStorage nicht verfügbar — kein Hard-Fail */
+    }
+  };
   const { showSuccess, showWarning, showError, confirm } = useFeedback();
   // Shims auf das zentrale Feedback-System — halten die bestehenden Aufrufstellen kompatibel
   const setGroupErrorSnackbar = (s: { open: boolean; message: string }) => { if (s.open) showWarning(s.message); };
@@ -2406,11 +2423,13 @@ const AppContent: React.FC = () => {
           onEditModules={() => setShowModuleManager(true)}
           onOpenDocumentation={handleOpenDocumentation}
           onShowShortcuts={() => setShowShortcuts(true)}
+          onShowOnboarding={() => setShowOnboarding(true)}
           validationSlot={<ValidationStatus />}
           workflowName={state.currentFlow?.name || "Workflow"}
         />
 
         <KeyboardShortcutsDialog open={showShortcuts} onClose={() => setShowShortcuts(false)} />
+        <OnboardingDialog open={showOnboarding} onClose={closeOnboarding} />
 
         {/* Workflow-Namen-Dialog */}
         <WorkflowNameDialog

--- a/src/components/HybridEditor/HybridEditor.tsx
+++ b/src/components/HybridEditor/HybridEditor.tsx
@@ -481,7 +481,7 @@ const HybridEditor: React.FC<HybridEditorProps> = ({
   return (
     <EditorContainer>
       {/* Linke Spalte: Hierarchische Baumansicht */}
-      <LeftColumn>
+      <LeftColumn role="region" aria-label="Element-Hierarchie">
         <Typography variant="subtitle1" sx={{ p: 2, fontWeight: 'bold', color: '#2A2E3F' }}>
           Element-Hierarchie
         </Typography>
@@ -496,7 +496,7 @@ const HybridEditor: React.FC<HybridEditorProps> = ({
       </LeftColumn>
 
       {/* Mittlere Spalte: Kontextbezogene Elementansicht */}
-      <MiddleColumn>
+      <MiddleColumn role="region" aria-label="Elemente der aktuellen Ebene">
         <Box sx={{ mb: 2 }}>
           <VisibilityLegend compact />
         </Box>
@@ -667,7 +667,7 @@ const HybridEditor: React.FC<HybridEditorProps> = ({
       </MiddleColumn>
 
       {/* Rechte Spalte: Eigenschaftspanel */}
-      <RightColumn>
+      <RightColumn role="region" aria-label="Eigenschaften des ausgewählten Elements">
         <EnhancedPropertyEditor
           element={selectedElementPath && selectedElementPath.length > 0
             ? getElementByPath(elements, selectedElementPath)

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -10,7 +10,8 @@ import {
   Edit as EditIcon,
   Extension as ModulesIcon,
   HelpOutline as HelpIcon,
-  KeyboardOutlined as KeyboardIcon
+  KeyboardOutlined as KeyboardIcon,
+  SchoolOutlined as OnboardingIcon
 } from '@mui/icons-material';
 
 interface NavigationProps {
@@ -25,6 +26,7 @@ interface NavigationProps {
   onEditModules: () => void;
   onOpenDocumentation?: () => void;
   onShowShortcuts?: () => void;
+  onShowOnboarding?: () => void;
   validationSlot?: React.ReactNode;
   workflowName: string;
 }
@@ -64,6 +66,7 @@ const Navigation: React.FC<NavigationProps> = ({
   onEditModules,
   onOpenDocumentation,
   onShowShortcuts,
+  onShowOnboarding,
   validationSlot,
   workflowName
 }) => {
@@ -148,6 +151,22 @@ const Navigation: React.FC<NavigationProps> = ({
 
         <RightActions>
           {validationSlot}
+          {onShowOnboarding && (
+            <Tooltip title="Erste Schritte (Editor-Tour)">
+              <IconButton
+                onClick={onShowOnboarding}
+                size="large"
+                aria-label="Erste Schritte anzeigen"
+                sx={{
+                  bgcolor: '#009F64',
+                  color: 'white',
+                  '&:hover': { bgcolor: '#008D58' }
+                }}
+              >
+                <OnboardingIcon />
+              </IconButton>
+            </Tooltip>
+          )}
           {onShowShortcuts && (
             <Tooltip title="Tastaturkürzel">
               <IconButton

--- a/src/components/common/OnboardingDialog.tsx
+++ b/src/components/common/OnboardingDialog.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { Box, Stack, Typography, Divider } from '@mui/material';
+import AccountTreeOutlinedIcon from '@mui/icons-material/AccountTreeOutlined';
+import WidgetsOutlinedIcon from '@mui/icons-material/WidgetsOutlined';
+import TuneOutlinedIcon from '@mui/icons-material/TuneOutlined';
+import DialogBase from './DialogBase';
+
+interface OnboardingDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const columns: { icon: React.ReactNode; title: string; text: string }[] = [
+  {
+    icon: <AccountTreeOutlinedIcon color="primary" />,
+    title: 'Struktur (links)',
+    text: 'Der Baum aller Elemente der aktuellen Seite. Hier navigierst du und wählst ein Element aus.',
+  },
+  {
+    icon: <WidgetsOutlinedIcon color="primary" />,
+    title: 'Elemente (Mitte)',
+    text: 'Der Inhalt der aktuellen Ebene. Hier fügst du Elemente hinzu und gehst in Gruppen hinein.',
+  },
+  {
+    icon: <TuneOutlinedIcon color="primary" />,
+    title: 'Eigenschaften (rechts)',
+    text: 'Bearbeitet das ausgewählte Element — Titel, Feld-ID, Optionen, Sichtbarkeit usw.',
+  },
+];
+
+const steps = [
+  'Seite anlegen oder auswählen (Leiste oben).',
+  'In der Mitte Elemente hinzufügen — Eingaben brauchen eine Feld-ID, dort landet der Wert.',
+  'Rechts die Eigenschaften setzen. Speichern exportiert den Flow als JSON.',
+];
+
+/**
+ * Erstkontakt-Onboarding: erklärt das 3-Spalten-Modell und den Grundablauf.
+ * Wird beim ersten Start automatisch gezeigt (localStorage) und ist über das
+ * Toolbar-Icon „Erste Schritte" jederzeit erneut aufrufbar.
+ */
+const OnboardingDialog: React.FC<OnboardingDialogProps> = ({ open, onClose }) => (
+  <DialogBase
+    open={open}
+    onClose={onClose}
+    title="Willkommen im Flow-Editor"
+    maxWidth="sm"
+    onConfirm={onClose}
+    confirmLabel="Los geht's"
+    hideCancel
+  >
+    <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+      Mit dem Flow-Editor baust du mehrseitige Formular-Workflows („Flows"), die später in der
+      doorbit-App gerendert werden. Der Editor hat drei Spalten:
+    </Typography>
+
+    <Stack spacing={1.5} sx={{ mb: 2 }}>
+      {columns.map((c) => (
+        <Box key={c.title} sx={{ display: 'flex', gap: 1.5, alignItems: 'flex-start' }}>
+          <Box sx={{ mt: '2px' }}>{c.icon}</Box>
+          <Box>
+            <Typography variant="subtitle2">{c.title}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              {c.text}
+            </Typography>
+          </Box>
+        </Box>
+      ))}
+    </Stack>
+
+    <Divider sx={{ my: 2 }} />
+
+    <Typography variant="subtitle2" sx={{ mb: 1 }}>
+      In drei Schritten zum Flow
+    </Typography>
+    <Box component="ol" sx={{ m: 0, pl: 2.5 }}>
+      {steps.map((s) => (
+        <Typography key={s} component="li" variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+          {s}
+        </Typography>
+      ))}
+    </Box>
+
+    <Typography variant="caption" sx={{ display: 'block', mt: 2, color: 'text.secondary' }}>
+      Diese Tour findest du jederzeit über das Symbol „Erste Schritte" oben rechts.
+    </Typography>
+  </DialogBase>
+);
+
+export default OnboardingDialog;


### PR DESCRIPTION
Macht den Editor selbsterklärend: ein Erstkontakt-Onboarding erklärt das 3-Spalten-Modell, das bisher nirgends erläutert war.

**Sauber von `main`** (kein Stacking — die #10–#12-Inhalte sind via #13 auf main).

## Kernlogik
- **`OnboardingDialog`** (neu, via `DialogBase`): erklärt die drei Spalten (Struktur │ Elemente │ Eigenschaften) und den Grundablauf in drei Schritten (Seite anlegen → Elemente hinzufügen inkl. Feld-ID-Hinweis → Eigenschaften setzen → Speichern/Export).
- **First-Run automatisch**: wird beim ersten Start gezeigt, danach via `localStorage` (`flowToolkit.onboardingSeen`) unterdrückt; localStorage-Fehler führen zu keinem Hard-Fail.
- **Jederzeit erneut aufrufbar**: neues Toolbar-Icon „Erste Schritte" (`onShowOnboarding`).
- **A11y**: die drei Editor-Spalten sind jetzt Landmarks (`role="region"` + `aria-label`) → bessere Screenreader-/Tastatur-Orientierung.
- Bestehende Empty-States (leere Mitte mit CTA, „Kein Element ausgewählt" rechts) waren bereits vorhanden und bleiben.

## Topic
Feature

## Labels
PWA (Website-UI), Feature

## Testen
1. `localStorage.removeItem('flowToolkit.onboardingSeen')` → App neu laden → Willkommens-Dialog erscheint automatisch.
2. „Los geht's" schließen → Reload → erscheint **nicht** erneut.
3. Toolbar-Icon „Erste Schritte" (Doktorhut) öffnet den Dialog jederzeit wieder.

## Verifikation
`tsc --noEmit` ok, `npm test` grün (110), `npm run build` (CI) erfolgreich.

https://claude.ai/code/session_01D2Pc4cAexeqUFrM1YonaJL

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2Pc4cAexeqUFrM1YonaJL)_