### PR TITLE
UX Phase 2-Rest: Drill-down visuell von Auswahl trennen + Tree-A11y

### DIFF
--- a/plans/ux-overhaul.md
+++ b/plans/ux-overhaul.md
@@ -40,9 +40,9 @@ Editor-Factory-Muster, `AccordionSection`, `TabbedTranslatableFields`, `ElementP
 - [x] Restliche `alert/confirm`-Reste auf Feedback-System — erledigt mit F1 (#9).
 
 ## Phase 2 — Orientierung & Navigation
-- [ ] „Auswählen" vs. „Drill-down" entkoppeln/visuell trennen; `selectedElementPath`↔`currentPath` vereinfachen (`HybridEditor.tsx`, `ElementHierarchyTree.tsx:362–387`).
+- [~] „Auswählen" vs. „Drill-down" **visuell getrennt** *(PR Phase 2-Rest)*: Funktional waren beide schon entkoppelt (Zeile=auswählen, Baum-Icon=drill, „Gruppe öffnen"-Button=drill). Neu: die Drill-Schaltfläche des aktuell geöffneten Containers zeigt einen **aktiven Zustand** (`isCurrentContext`) + `aria-pressed` → „wo bin ich drin" ≠ „was bearbeite ich". Der tiefere `selectedElementPath`↔`currentPath`-State-Refactor bleibt **bewusst offen** (spekulativ, braucht Live-Usability-Runde).
 - [x] **Empty States + Erstkontakt-Onboarding** *(PR Phase 2)*: `OnboardingDialog` (via DialogBase) erklärt das 3-Spalten-Modell + Grundablauf; First-Run automatisch (localStorage `flowToolkit.onboardingSeen`), jederzeit über Toolbar-Icon „Erste Schritte" erneut aufrufbar. Leere Mitte mit CTA war bereits vorhanden.
-- [~] Accessibility: 3 Spalten als Landmarks (`role="region"` + `aria-label`) **erledigt** *(PR Phase 2)*; Fokus-Management/Kontraste/weitere Landmarks weiterhin offen.
+- [~] Accessibility: 3 Spalten als Landmarks (`role="region"` + `aria-label`) **erledigt** *(PR Phase 2)*; Hierarchie-Baum: `aria-label` auf Auf-/Zuklappen- & Drill-Buttons, `aria-current` für die Auswahl, `aria-pressed` am Drill-Button **erledigt** *(PR Phase 2-Rest)*. Fokus-Management/Kontraste weiterhin offen.
 - [x] **Keyboard-Shortcuts-Hilfe** *(PR #11)*: Dialog (via DialogBase) listet die vorhandenen, bislang undokumentierten Shortcuts (Strg+Z/Y/S, Esc); Tastatur-Icon in der Toolbar.
 
 ## Phase 3 — Auffindbarkeit & Effizienz

--- a/src/components/HybridEditor/ElementHierarchyTree.tsx
+++ b/src/components/HybridEditor/ElementHierarchyTree.tsx
@@ -219,6 +219,9 @@ const TreeNode: React.FC<{
   const isSelected = arePathsEqual(path, selectedPath);
   const isInCurrentPath = path.length <= currentPath.length &&
                           path.every((value, index) => value === currentPath[index]);
+  // Genau dieser Container ist aktuell „geöffnet" (seine Kinder füllen die mittlere Spalte).
+  // Drill-down ≠ Auswahl: das wird an der Drill-Schaltfläche sichtbar gemacht.
+  const isCurrentContext = currentPath.length > 0 && arePathsEqual(path, currentPath);
 
   // Verwende die importierte getSubElements Funktion
   const children = React.useMemo(() => getSubElements(element), [element]);
@@ -226,6 +229,10 @@ const TreeNode: React.FC<{
 
   // Bestimme den Container-Typ des Elements
   const containerType = React.useMemo(() => getContainerType(element), [element]);
+  const containerColor = containerType === 'array' ? '#F05B29' :
+                         containerType === 'chipgroup' ? '#3F51B5' : '#009F64';
+  const containerColorDark = containerType === 'array' ? '#D04E24' :
+                             containerType === 'chipgroup' ? '#303F9F' : '#008555';
 
   // Bestimme, ob das Element eine Visibility Condition hat
   const hasVisibilityCondition = () => {
@@ -311,12 +318,14 @@ const TreeNode: React.FC<{
         isLastChild={isLastChildInLevel}
         hasChildren={hasActualChildren}
         onClick={() => onSelectElement(path)}
+        aria-current={isSelected ? 'true' : undefined}
         sx={isDirectMatch ? { backgroundColor: 'rgba(25, 118, 210, 0.08)', fontWeight: 'bold' } : undefined}
       >
         <TreeItemContent>
           {hasActualChildren ? (
             <IconButton
               size="small"
+              aria-label={expanded ? 'Unterelemente zuklappen' : 'Unterelemente aufklappen'}
               sx={{ position: 'relative' }} // Für ::before Pseudoelement
               onClick={(e) => {
                 e.stopPropagation();
@@ -359,26 +368,31 @@ const TreeNode: React.FC<{
           />
 
           {hasActualChildren && ( // Verwende hasActualChildren
-            <Tooltip title={`${containerType === 'group' ? 'Gruppe öffnen' :
-                             containerType === 'array' ? 'Array öffnen' :
-                             containerType === 'chipgroup' ? 'Chips anzeigen' :
-                             containerType === 'custom' ? 'Custom-Element öffnen' :
-                             containerType === 'subflow' ? 'Subflow öffnen' :
-                             'Unterelemente anzeigen'}`}>
+            <Tooltip title={isCurrentContext
+              ? 'Geöffnet — der Inhalt erscheint in der mittleren Spalte'
+              : (containerType === 'group' ? 'Gruppe öffnen' :
+                 containerType === 'array' ? 'Array öffnen' :
+                 containerType === 'chipgroup' ? 'Chips anzeigen' :
+                 containerType === 'custom' ? 'Custom-Element öffnen' :
+                 containerType === 'subflow' ? 'Subflow öffnen' :
+                 'Unterelemente anzeigen')}>
               <IconButton
                 size="small"
+                aria-label={isCurrentContext
+                  ? `${getDisplayName()}: geöffnet`
+                  : `${getDisplayName()} öffnen — Inhalt in der mittleren Spalte anzeigen`}
+                aria-pressed={isCurrentContext}
                 onClick={(e) => {
                   e.stopPropagation();
                   onDrillDown(path);
                 }}
                 sx={{
                   ml: 'auto',
-                  color: containerType === 'group' ? '#009F64' :
-                         containerType === 'array' ? '#F05B29' :
-                         containerType === 'chipgroup' ? '#3F51B5' :
-                         containerType === 'custom' ? '#009F64' :
-                         containerType === 'subflow' ? '#009F64' :
-                         '#009F64'
+                  color: isCurrentContext ? '#fff' : containerColor,
+                  ...(isCurrentContext ? {
+                    bgcolor: containerColor,
+                    '&:hover': { bgcolor: containerColorDark },
+                  } : {}),
                 }}
               >
                 <AccountTreeIcon fontSize="small" />


### PR DESCRIPTION
Schließt Phase 2 ab: macht den Unterschied zwischen **Auswählen** (Element bearbeiten) und **Drill-down** (in einen Container hineinnavigieren) sichtbar — bisher visuell nicht unterscheidbar.

**Sauber von `main`** (kein Stacking).

## Kernlogik
- **Befund**: Auswahl und Drill-down waren bereits *funktional* getrennt (Tree: Zeilen-Klick = auswählen, Baum-Icon = Drill-down; Mitte: Klick = auswählen, „Gruppe öffnen"-Button = Drill-down). Es fehlte die *visuelle/A11y*-Klarheit — ein riskanter State-Refactor ist hier nicht gerechtfertigt.
- **Aktiver Drill-Zustand**: Die Drill-Schaltfläche des aktuell geöffneten Containers (`isCurrentContext`) wird gefüllt dargestellt + `aria-pressed` → „wo bin ich drin" ist eindeutig von „was bearbeite ich" (grün hervorgehobene Auswahl) getrennt.
- **A11y**: `aria-label` auf den bisher icon-only Auf-/Zuklappen- und Drill-Buttons; `aria-current` für die ausgewählte Zeile.
- **Bewusst aufgeschoben**: der tiefere `selectedElementPath`↔`currentPath`-State-Refactor (spekulativ, braucht eine Live-Usability-Runde — so auch im Plan vermerkt).

## Topic
Feature / Refactoring

## Labels
PWA (Website-UI)

## Testen
1. Flow mit einer Gruppe/Array öffnen → in der Hierarchie (links) auf das Baum-Icon eines Containers klicken (Drill-down).
2. Dessen Drill-Icon erscheint jetzt **gefüllt** (aktiv) = „dieser Container ist geöffnet"; die mittlere Spalte zeigt seinen Inhalt.
3. Eine Zeile anklicken → grüne Auswahl-Markierung, rechte Spalte zeigt die Eigenschaften — unabhängig vom geöffneten Container.

## Verifikation
`tsc --noEmit` ok, `npm test` grün (110), `npm run build` (CI) erfolgreich.

https://claude.ai/code/session_01D2Pc4cAexeqUFrM1YonaJL

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2Pc4cAexeqUFrM1YonaJL)_