### PR TITLE
UX Phase 3: Verschachtelungsregeln vorab im Element-Picker

### DIFF
--- a/plans/ux-overhaul.md
+++ b/plans/ux-overhaul.md
@@ -47,7 +47,7 @@ Editor-Factory-Muster, `AccordionSection`, `TabbedTranslatableFields`, `ElementP
 
 ## Phase 3 — Auffindbarkeit & Effizienz
 - [~] **Element-Picker: Suche + Beschreibungen** *(PR Phase 3)*: Befund — die `ElementPalette.tsx`-Komponente ist **tot** (in `App.tsx` auskommentiert, nicht gerendert). Der real genutzte Picker ist der `ElementTypeDialog` in `ElementContextView`. Dort ergänzt: Suchfeld (filtert Label/Typ/Beschreibung über beide Kategorien) + sichtbare **Beschreibung je Typ** (statt nur Hover-Tooltip → besser auffindbar/Touch). Offen: tote `ElementPalette` aufräumen/entfernen.
-- [ ] Drag&Drop: Drop-Indikatoren + Verschachtelungsregeln vorab (ungültiges Hinzufügen deaktivieren).
+- [~] **Verschachtelungsregeln vorab** *(PR Phase 3)*: Regeln in `utils/nestingRules.ts` extrahiert (Single Source of Truth, Unit-Test) und im Element-Typ-Dialog angewandt — unerlaubte Typen werden **deaktiviert + mit Grund** angezeigt, statt erst nach der Auswahl einen Fehler zu werfen (Fallback in App.tsx bleibt). Offen: ausgefeiltere Drop-Indikatoren beim Reorder-Drag (heute simple Top-Border).
 - [ ] Multi-Select-Affordance (sichtbarer Toggle/Checkboxen).
 - [ ] Modul-Zuordnung immer sichtbar. *(INLINE/CATALOG- & Modul-Tooltips bereits via PR #8.)*
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import PageNavigator from './components/PageNavigator/PageNavigator';
 import CopyElementToPageDialog from './components/HybridEditor/CopyElementToPageDialog';
 import ExportElementToFileDialog from './components/HybridEditor/ExportElementToFileDialog';
 import { deepCloneElement } from './utils/deepCloneUtils';
+import { isElementAllowedInParent } from './utils/nestingRules';
 // DndProvider wird jetzt in index.tsx importiert
 // import { DndProvider } from './components/DndProvider';
 import { EditorProvider, useEditor, getElementByPath, getContainerType } from './context/EditorContext';
@@ -1718,38 +1719,7 @@ const AppContent: React.FC = () => {
   const currentPage = state.currentFlow?.pages_edit.find(page => page.id === state.selectedPageId);
   const currentElements = currentPage?.elements || [];
 
-  // Hilfsfunktion zur Prüfung der Verschachtelungsregeln
-  const isElementAllowedInParent = (elementType: string, parentType: string): { allowed: boolean, message: string } => {
-    // Prüfe, ob das Ziel eine ChipGroup ist
-    if (parentType === 'ChipGroupUIElement') {
-      // Nur BooleanUIElements in ChipGroups erlauben
-      return {
-        allowed: elementType === 'BooleanUIElement',
-        message: "Nur Boolean-Elemente können in Chip-Gruppen hinzugefügt werden"
-      };
-    }
-
-    // Prüfe, ob das Ziel ein Array-Element ist
-    if (parentType === 'ArrayUIElement') {
-      // Arrays dürfen keine weiteren Arrays oder komplexe Elemente enthalten
-      const isComplex = ['ArrayUIElement', 'GroupUIElement', 'CustomUIElement', 'ChipGroupUIElement'].includes(elementType);
-      return {
-        allowed: !isComplex,
-        message: "Arrays dürfen keine weiteren Arrays oder komplexe Elemente enthalten"
-      };
-    }
-
-    // Prüfe, ob das Ziel ein Gruppen-Element ist
-    if (parentType === 'GroupUIElement') {
-      // Gruppen dürfen keine weiteren Gruppen enthalten
-      return {
-        allowed: elementType !== 'GroupUIElement',
-        message: "Gruppen dürfen keine weiteren Gruppen enthalten"
-      };
-    }
-
-    return { allowed: true, message: "" };
-  };
+  // Verschachtelungsregeln: siehe utils/nestingRules.ts (geteilt mit dem Element-Typ-Dialog)
 
   // Element-Handler für Haupt- und verschachtelte Elemente
   // Verbesserte Version, die besser mit der Komplexität von doorbit_original.json umgehen kann

--- a/src/components/HybridEditor/ElementContextView.tsx
+++ b/src/components/HybridEditor/ElementContextView.tsx
@@ -62,6 +62,7 @@ import { useDrag, useDrop } from 'react-dnd';
 
 import { PatternLibraryElement } from '../../models/listingFlow';
 import { arePathsEqual } from '../../utils/pathUtils';
+import { isElementAllowedInParent, resolvePatternType } from '../../utils/nestingRules';
 import { getContainerType } from '../../context/EditorContext';
 import { logger } from '../../utils/logger';
 
@@ -271,7 +272,8 @@ const ElementTypeDialog: React.FC<{
   open: boolean;
   onClose: () => void;
   onSelectElementType: (type: string) => void;
-}> = ({ open, onClose, onSelectElementType }) => {
+  parentType?: string;
+}> = ({ open, onClose, onSelectElementType, parentType }) => {
   const [tabIndex, setTabIndex] = useState(0);
   const [search, setSearch] = useState('');
 
@@ -299,12 +301,25 @@ const ElementTypeDialog: React.FC<{
   const basicElements = elementTypes.filter(e => e.category === 'basic');
   const complexElements = elementTypes.filter(e => e.category === 'complex');
 
-  const renderItem = (element: ElementType) => (
-    <ListItemButton key={element.type} onClick={() => handlePick(element.type)} alignItems="flex-start">
-      <ListItemIcon sx={{ mt: 0.5 }}>{element.icon}</ListItemIcon>
-      <ListItemText primary={element.label} secondary={element.description} />
-    </ListItemButton>
-  );
+  const renderItem = (element: ElementType) => {
+    // Verschachtelungsregeln vorab anwenden: unerlaubte Typen deaktivieren statt
+    // erst nach der Auswahl einen Fehler zu zeigen.
+    const rule = parentType
+      ? isElementAllowedInParent(resolvePatternType(element.type), parentType)
+      : { allowed: true, message: '' };
+    const disabled = !rule.allowed;
+    return (
+      <ListItemButton
+        key={element.type}
+        onClick={() => handlePick(element.type)}
+        alignItems="flex-start"
+        disabled={disabled}
+      >
+        <ListItemIcon sx={{ mt: 0.5 }}>{element.icon}</ListItemIcon>
+        <ListItemText primary={element.label} secondary={disabled ? rule.message : element.description} />
+      </ListItemButton>
+    );
+  };
 
   return (
     <Dialog
@@ -1086,6 +1101,14 @@ const ElementContextView: React.FC<ElementContextViewProps> = ({
     setElementTypeDialogOpen(true);
   }, []);
 
+  // Eltern-Typ für die Vorab-Validierung im Dialog: nur bestimmbar, wenn als Unterelement
+  // eines direkten Kindes der aktuellen Ebene hinzugefügt wird (dort ist das Element bekannt).
+  // Für „auf aktueller Ebene hinzufügen" (null) greift weiterhin die Validierung in App.tsx.
+  const dialogParentType =
+    selectedElementForDialog && selectedElementForDialog.length === currentPath.length + 1
+      ? elements[selectedElementForDialog[selectedElementForDialog.length - 1]]?.element?.pattern_type
+      : undefined;
+
   // Rendere die Elementkarten
   const renderElementCards = () => {
     logger.log('renderElementCards - elements:', elements);
@@ -1138,6 +1161,7 @@ const ElementContextView: React.FC<ElementContextViewProps> = ({
         open={elementTypeDialogOpen}
         onClose={() => setElementTypeDialogOpen(false)}
         onSelectElementType={handleSelectElementType}
+        parentType={dialogParentType}
       />
 
       {elements.length > 0 ? (

--- a/src/utils/nestingRules.test.ts
+++ b/src/utils/nestingRules.test.ts
@@ -1,0 +1,50 @@
+import { isElementAllowedInParent, resolvePatternType } from './nestingRules';
+
+describe('nestingRules', () => {
+  describe('ChipGroup', () => {
+    it('erlaubt nur Boolean-Elemente', () => {
+      expect(isElementAllowedInParent('BooleanUIElement', 'ChipGroupUIElement').allowed).toBe(true);
+      expect(isElementAllowedInParent('StringUIElement', 'ChipGroupUIElement').allowed).toBe(false);
+      expect(isElementAllowedInParent('GroupUIElement', 'ChipGroupUIElement').allowed).toBe(false);
+    });
+  });
+
+  describe('Array', () => {
+    it('verbietet Arrays und komplexe Elemente', () => {
+      expect(isElementAllowedInParent('ArrayUIElement', 'ArrayUIElement').allowed).toBe(false);
+      expect(isElementAllowedInParent('GroupUIElement', 'ArrayUIElement').allowed).toBe(false);
+      expect(isElementAllowedInParent('CustomUIElement', 'ArrayUIElement').allowed).toBe(false);
+      expect(isElementAllowedInParent('ChipGroupUIElement', 'ArrayUIElement').allowed).toBe(false);
+    });
+    it('erlaubt einfache Elemente', () => {
+      expect(isElementAllowedInParent('StringUIElement', 'ArrayUIElement').allowed).toBe(true);
+      expect(isElementAllowedInParent('NumberUIElement', 'ArrayUIElement').allowed).toBe(true);
+    });
+  });
+
+  describe('Gruppe', () => {
+    it('verbietet verschachtelte Gruppen, erlaubt den Rest', () => {
+      expect(isElementAllowedInParent('GroupUIElement', 'GroupUIElement').allowed).toBe(false);
+      expect(isElementAllowedInParent('ArrayUIElement', 'GroupUIElement').allowed).toBe(true);
+      expect(isElementAllowedInParent('StringUIElement', 'GroupUIElement').allowed).toBe(true);
+    });
+  });
+
+  describe('unbeschränkte Eltern', () => {
+    it('erlaubt alles (z. B. Custom/Subflow)', () => {
+      expect(isElementAllowedInParent('GroupUIElement', 'CustomUIElement').allowed).toBe(true);
+      expect(isElementAllowedInParent('ArrayUIElement', 'CustomUIElement').allowed).toBe(true);
+    });
+  });
+
+  describe('resolvePatternType', () => {
+    it('bildet Custom-Dialog-Varianten auf CustomUIElement ab', () => {
+      expect(resolvePatternType('CustomUIElement_SCANNER')).toBe('CustomUIElement');
+      expect(resolvePatternType('CustomUIElement_ADDRESS')).toBe('CustomUIElement');
+    });
+    it('lässt normale Typen unverändert', () => {
+      expect(resolvePatternType('BooleanUIElement')).toBe('BooleanUIElement');
+      expect(resolvePatternType('GroupUIElement')).toBe('GroupUIElement');
+    });
+  });
+});

--- a/src/utils/nestingRules.ts
+++ b/src/utils/nestingRules.ts
@@ -1,0 +1,54 @@
+/**
+ * Verschachtelungsregeln für Flow-Elemente.
+ *
+ * Single Source of Truth dafür, welche Element-Typen in welchen Containern erlaubt sind.
+ * Wird sowohl beim tatsächlichen Hinzufügen (App.tsx) als auch im Element-Typ-Dialog
+ * (zum Vorab-Deaktivieren unerlaubter Optionen) verwendet.
+ */
+
+export interface NestingRuleResult {
+  allowed: boolean;
+  message: string;
+}
+
+/**
+ * Prüft, ob ein Element-Typ (pattern_type) in einem Eltern-Container (pattern_type)
+ * erlaubt ist. Gibt bei Verbot eine erklärende Meldung zurück.
+ */
+export function isElementAllowedInParent(elementType: string, parentType: string): NestingRuleResult {
+  // ChipGroup: nur Boolean-Elemente
+  if (parentType === 'ChipGroupUIElement') {
+    return {
+      allowed: elementType === 'BooleanUIElement',
+      message: 'Nur Boolean-Elemente können in Chip-Gruppen hinzugefügt werden',
+    };
+  }
+
+  // Array: keine weiteren Arrays oder komplexen Elemente
+  if (parentType === 'ArrayUIElement') {
+    const isComplex = ['ArrayUIElement', 'GroupUIElement', 'CustomUIElement', 'ChipGroupUIElement'].includes(elementType);
+    return {
+      allowed: !isComplex,
+      message: 'Arrays dürfen keine weiteren Arrays oder komplexe Elemente enthalten',
+    };
+  }
+
+  // Gruppe: keine weiteren Gruppen
+  if (parentType === 'GroupUIElement') {
+    return {
+      allowed: elementType !== 'GroupUIElement',
+      message: 'Gruppen dürfen keine weiteren Gruppen enthalten',
+    };
+  }
+
+  return { allowed: true, message: '' };
+}
+
+/**
+ * Bildet die Dialog-Typen (z. B. `CustomUIElement_SCANNER`) auf den tatsächlichen
+ * `pattern_type` ab, der beim Erstellen entsteht (`CustomUIElement`). Für die
+ * Regelprüfung im Dialog nötig, da dort die spezifischen Custom-Varianten gelistet sind.
+ */
+export function resolvePatternType(dialogType: string): string {
+  return dialogType.startsWith('CustomUIElement_') ? 'CustomUIElement' : dialogType;
+}


### PR DESCRIPTION
Verhindert ungültige Verschachtelungen, bevor sie passieren: der Element-Picker deaktiviert unerlaubte Typen statt erst nach der Auswahl einen Fehler zu werfen.

**Sauber von `main`** (kein Stacking).

## Kernlogik
- **Regeln extrahiert** nach `utils/nestingRules.ts` (Single Source of Truth, mit Unit-Test). `App.tsx` nutzt jetzt dieses Util statt einer lokalen Kopie — keine Verhaltensänderung beim tatsächlichen Hinzufügen.
- **Vorab-Deaktivierung im Dialog**: Beim Hinzufügen eines Unterelements werden Typen, die im jeweiligen Container nicht erlaubt sind, **ausgegraut + mit Begründung** als Sekundärtext gezeigt (z. B. „Gruppen dürfen keine weiteren Gruppen enthalten", „Nur Boolean-Elemente … in Chip-Gruppen", „Arrays dürfen keine komplexen Elemente enthalten").
- **`parentType`-Ableitung**: bestimmbar, wenn als Unterelement eines bekannten Kindes der aktuellen Ebene hinzugefügt wird. Für „auf aktueller Ebene hinzufügen" bleibt die bestehende Validierung in `App.tsx` (Fehler-Toast) als Fallback — kein Regressionsrisiko.

## Topic
Feature / Refactoring

## Labels
PWA (Website-UI)

## Testen
1. Eine Gruppe anlegen → in der Gruppen-Karte „Unterelement hinzufügen".
2. Im Dialog ist „Gruppe" ausgegraut mit Begründung; andere Typen wählbar.
3. Analog bei Array (komplexe Typen gesperrt) und Chip-Gruppe (nur Boolean).

## Offen (Phase 3)
- Ausgefeiltere Drop-Indikatoren beim Reorder-Drag (heute simple Top-Border).
- Tote `ElementPalette.tsx` aufräumen.

## Verifikation
`tsc --noEmit` ok, `npm test` grün (117, +7 `nestingRules`-Tests), `npm run build` (CI) erfolgreich.

https://claude.ai/code/session_01D2Pc4cAexeqUFrM1YonaJL

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2Pc4cAexeqUFrM1YonaJL)_