### PR TITLE
refactor(ux/F2): zentrale Farb-Tokens als Single Source of Truth

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { CssBaseline, ThemeProvider, createTheme, Box } from '@mui/material';
 import { v4 as uuidv4 } from 'uuid';
+import { tokens } from './theme/tokens';
 import { generateUUID, transformFlowForExport } from './utils/uuidUtils';
 import styled from 'styled-components';
 import WorkflowNameDialog from './components/WorkflowNameDialog/WorkflowNameDialog';
@@ -52,52 +53,52 @@ import {
 const theme = createTheme({
   palette: {
     primary: {
-      main: '#009F64', // Grün (Corporate Branding)
-      dark: '#005D3A', // Dunkelgrün
-      light: '#4CC695', // Helleres Grün
-      contrastText: '#FFFFFF',
+      main: tokens.brand.green, // Grün (Corporate Branding)
+      dark: tokens.brand.greenDark, // Dunkelgrün
+      light: tokens.brand.greenLight, // Helleres Grün
+      contrastText: tokens.surface.paper,
     },
     secondary: {
-      main: '#F05B29', // Orange/Rot (Corporate Branding)
-      dark: '#D04010',
-      light: '#F78057',
-      contrastText: '#FFFFFF',
+      main: tokens.brand.orange, // Orange/Rot (Corporate Branding)
+      dark: tokens.brand.orangeDark,
+      light: tokens.brand.orangeLight,
+      contrastText: tokens.surface.paper,
     },
     text: {
-      primary: '#2A2E3F', // Dunkelblau für Überschriften
-      secondary: '#343951', // Dunkelgrau für normalen Text
+      primary: tokens.text.primary, // Dunkelblau für Überschriften
+      secondary: tokens.text.secondary, // Dunkelgrau für normalen Text
     },
     background: {
-      default: '#F8FAFC', // Sehr helles Grau/Weiß
-      paper: '#FFFFFF',
+      default: tokens.surface.appBg, // Sehr helles Grau/Weiß
+      paper: tokens.surface.paper,
     },
     grey: {
-      300: '#E0E0E0',
-      400: '#BDBDBD',
-      500: '#848BA5', // Grau für Icons und sekundäre Elemente
+      300: tokens.neutral.border,
+      400: tokens.neutral.borderStrong,
+      500: tokens.neutral.icon, // Grau für Icons und sekundäre Elemente
     },
     error: {
-      main: '#F05B29', // Orange/Rot für Fehler und Warnungen
+      main: tokens.brand.orange, // Orange/Rot für Fehler und Warnungen
     },
     info: {
-      main: '#009F64', // Grün für Infos
+      main: tokens.brand.green, // Grün für Infos
     },
   },
   typography: {
     fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
     h6: {
       fontWeight: 500,
-      color: '#2A2E3F',
+      color: tokens.text.primary,
     },
     subtitle1: {
       fontWeight: 500,
-      color: '#343951',
+      color: tokens.text.secondary,
     },
     body1: {
-      color: '#343951',
+      color: tokens.text.secondary,
     },
     body2: {
-      color: '#343951',
+      color: tokens.text.secondary,
     },
   },
   components: {
@@ -2418,7 +2419,7 @@ const AppContent: React.FC = () => {
 
         {/* Seitennavigation */}
         {state.currentFlow && (
-          <Box sx={{ borderBottom: 1, borderColor: 'divider', bgcolor: '#f5f5f5' }}>
+          <Box sx={{ borderBottom: 1, borderColor: 'divider', bgcolor: tokens.surface.subtle }}>
             <PageNavigator
               pages={state.currentFlow.pages_edit}
               selectedPageId={state.selectedPageId}
@@ -2494,7 +2495,7 @@ const AppContent: React.FC = () => {
         <Box
           sx={{
             height: '5vh',
-            borderTop: '1px solid #ddd',
+            borderTop: `1px solid ${tokens.neutral.border}`,
             overflow: 'hidden',
             position: 'relative',
             '&:hover': {

--- a/src/components/EditorArea/EditorArea.tsx
+++ b/src/components/EditorArea/EditorArea.tsx
@@ -29,6 +29,7 @@ import {
 import { PatternLibraryElement } from '../../models/listingFlow';
 import { logger } from '../../utils/logger';
 import { UIElement, GroupUIElement } from '../../models/uiElements';
+import { tokens } from '../../theme/tokens';
 import { useEditor, getElementByPath } from '../../context/EditorContext'; // useEditor importieren
 import { useFieldValues } from '../../context/FieldValuesContext';
 import { evaluateVisibilityCondition } from '../../utils/visibilityUtils';
@@ -39,7 +40,7 @@ import { useDrop } from 'react-dnd';
 const EditorContainer = styled(Paper)`
   flex: 1;
   padding: 1rem;
-  background-color: #F8FAFC;
+  background-color: ${tokens.surface.appBg};
   min-height: 70vh;
   display: flex;
   flex-direction: column;
@@ -62,12 +63,12 @@ const ElementContainer = styled(Card)<{
         : props.depth === 2
           ? 'rgba(0, 159, 100, 0.05)'
           : 'rgba(0, 159, 100, 0.08)'};
-  border: 1px solid ${props => props.selected ? '#009F64' : '#e0e0e0'};
+  border: 1px solid ${props => props.selected ? tokens.brand.green : tokens.neutral.border};
   box-shadow: ${props =>
     props.isDragging
       ? '0 5px 10px rgba(0, 0, 0, 0.2)'
       : props.selected
-        ? '0 0 0 2px #009F64'
+        ? `0 0 0 2px ${tokens.brand.green}`
         : 'none'};
   opacity: ${props => props.isDragging ? 0.6 : 1};
   cursor: ${props => props.isDragging ? 'grabbing' : 'default'};
@@ -97,22 +98,22 @@ const EmptyState = styled(({ $isOver, ...props }) => <Box {...props} />)<{ $isOv
   justify-content: center;
   height: 100%;
   text-align: center;
-  color: #343951;
+  color: ${tokens.text.secondary};
   padding: 2rem;
   background-color: ${props => props.$isOver ? 'rgba(0, 159, 100, 0.05)' : 'rgba(0, 159, 100, 0.02)'};
   border-radius: 8px;
-  border: 2px dashed ${props => props.$isOver ? '#009F64' : 'rgba(0, 159, 100, 0.2)'};
+  border: 2px dashed ${props => props.$isOver ? tokens.brand.green : 'rgba(0, 159, 100, 0.2)'};
   transition: all 0.2s ease;
 `;
 
 // Filter transient props for DropZone
 const DropZone = styled(({ $isOver, ...props }) => <Box {...props} />)<{ $isOver?: boolean }>`
-  border: 2px dashed ${props => props.$isOver ? '#009F64' : 'rgba(0, 159, 100, 0.3)'};
+  border: 2px dashed ${props => props.$isOver ? tokens.brand.green : 'rgba(0, 159, 100, 0.3)'};
   border-radius: 8px;
   padding: 1rem;
   margin: 0.5rem 0;
   text-align: center;
-  color: #343951;
+  color: ${tokens.text.secondary};
   background-color: ${props => props.$isOver ? 'rgba(0, 159, 100, 0.05)' : 'transparent'};
   transition: all 0.2s ease;
 `;
@@ -124,7 +125,7 @@ const ElementDropZoneWrapper = styled(Box)`
 
 const ElementDropZoneLine = styled(Box)<{ canDrop: boolean }>`
   height: 2px;
-  background-color: ${props => props.canDrop ? '#009F64' : '#F05B29'};
+  background-color: ${props => props.canDrop ? tokens.brand.green : tokens.brand.orange};
   width: 100%;
   transition: all 0.2s ease;
 `;
@@ -133,7 +134,7 @@ const AddElementButton = styled(Button)`
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
   background-color: rgba(0, 159, 100, 0.1);
-  color: #009F64;
+  color: ${tokens.brand.green};
   &:hover {
     background-color: rgba(0, 159, 100, 0.2);
   }

--- a/src/components/EditorArea/FloatingActionBar.tsx
+++ b/src/components/EditorArea/FloatingActionBar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box, Button, Paper, Typography } from '@mui/material';
 import GroupWorkIcon from '@mui/icons-material/GroupWork';
 import ClearIcon from '@mui/icons-material/Clear';
+import { tokens } from '../../theme/tokens';
 
 interface FloatingActionBarProps {
   selectedCount: number;
@@ -35,11 +36,11 @@ const FloatingActionBar: React.FC<FloatingActionBarProps> = ({
         px: 3,
         py: 1.5,
         borderRadius: 3,
-        backgroundColor: '#fff',
-        border: '1px solid #E0E0E0',
+        backgroundColor: tokens.surface.paper,
+        border: `1px solid ${tokens.neutral.border}`,
       }}
     >
-      <Typography variant="body2" sx={{ fontWeight: 600, color: '#1976D2', whiteSpace: 'nowrap' }}>
+      <Typography variant="body2" sx={{ fontWeight: 600, color: tokens.accentBlue.main, whiteSpace: 'nowrap' }}>
         {selectedCount} {selectedCount === 1 ? 'Element' : 'Elemente'} ausgewählt
       </Typography>
 
@@ -50,8 +51,8 @@ const FloatingActionBar: React.FC<FloatingActionBarProps> = ({
           startIcon={<GroupWorkIcon />}
           onClick={onWrapInGroup}
           sx={{
-            backgroundColor: '#009F64',
-            '&:hover': { backgroundColor: '#007A4D' },
+            backgroundColor: tokens.brand.green,
+            '&:hover': { backgroundColor: tokens.brand.greenDeep },
             textTransform: 'none',
             whiteSpace: 'nowrap',
           }}

--- a/src/components/EditorArea/WrapInGroupDialog.tsx
+++ b/src/components/EditorArea/WrapInGroupDialog.tsx
@@ -16,6 +16,7 @@ import {
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import GroupWorkIcon from '@mui/icons-material/GroupWork';
 import { v4 as uuidv4 } from 'uuid';
+import { tokens } from '../../theme/tokens';
 
 interface WrapInGroupDialogProps {
   open: boolean;
@@ -55,7 +56,7 @@ const WrapInGroupDialog: React.FC<WrapInGroupDialogProps> = ({
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-        <GroupWorkIcon sx={{ color: '#009F64' }} />
+        <GroupWorkIcon sx={{ color: tokens.brand.green }} />
         Zu Gruppe zusammenfassen
       </DialogTitle>
 
@@ -118,8 +119,8 @@ const WrapInGroupDialog: React.FC<WrapInGroupDialogProps> = ({
           onClick={handleConfirm}
           disabled={!isValid}
           sx={{
-            backgroundColor: '#009F64',
-            '&:hover': { backgroundColor: '#007A4D' },
+            backgroundColor: tokens.brand.green,
+            '&:hover': { backgroundColor: tokens.brand.greenDeep },
             textTransform: 'none',
           }}
         >

--- a/src/components/ElementPalette/ElementPalette.tsx
+++ b/src/components/ElementPalette/ElementPalette.tsx
@@ -22,15 +22,16 @@ import {
   TableChart as TableIcon,
   ContactMail as ContactIcon
 } from '@mui/icons-material';
+import { tokens } from '../../theme/tokens';
 
 const PaletteContainer = styled(Paper)`
   width: 250px;
   height: 100vh;
-  background-color: #F0F2F4;
+  background-color: ${tokens.surface.subtleAlt};
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border-right: 1px solid #E0E0E0;
+  border-right: 1px solid ${tokens.neutral.border};
 `;
 
 const ScrollableSection = styled.div`
@@ -53,8 +54,8 @@ const ComplexElementsSection = styled.div`
 
 const PaletteHeader = styled(Typography)`
   padding: 16px;
-  background-color: #F0F2F4;
-  color: #2A2E3F;
+  background-color: ${tokens.surface.subtleAlt};
+  color: ${tokens.text.primary};
   font-weight: 500;
 `;
 
@@ -65,10 +66,10 @@ const StyledListItemButton = styled(ListItemButton)`
   border-radius: 4px;
   margin: 2px 8px;
   padding: 8px 16px;
-  color: #2A2E3F;
+  color: ${tokens.text.primary};
 
   .MuiListItemIcon-root {
-    color: #2A2E3F;
+    color: ${tokens.text.primary};
   }
 
   &[draggable="true"] {
@@ -151,7 +152,7 @@ const ElementPalette: React.FC<ElementPaletteProps> = ({ onElementClick }) => {
     fontSize: '0.75rem',
     backgroundColor: activeTab === tab ? 'rgba(0, 159, 100, 0.1)' : 'transparent',
     fontWeight: activeTab === tab ? 'bold' : 'normal',
-    color: activeTab === tab ? '#009F64' : '#2A2E3F',
+    color: activeTab === tab ? tokens.brand.green : tokens.text.primary,
     '&:hover': {
       backgroundColor: activeTab === tab ? 'rgba(0, 159, 100, 0.15)' : 'rgba(0, 159, 100, 0.05)'
     }

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,11 +1,12 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { Button, Typography, Box, Paper } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import { tokens } from '../../theme/tokens';
 
 const ErrorContainer = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(3),
-  backgroundColor: '#fff8f8',
-  border: '1px solid #ffcdd2',
+  backgroundColor: tokens.status.errorBg,
+  border: `1px solid ${tokens.status.errorBorder}`,
   borderRadius: theme.shape.borderRadius,
   maxWidth: '800px',
   marginLeft: 'auto',

--- a/src/components/HybridEditor/CopyElementToPageDialog.tsx
+++ b/src/components/HybridEditor/CopyElementToPageDialog.tsx
@@ -23,6 +23,7 @@ import {
 import FileCopyIcon from '@mui/icons-material/FileCopy';
 
 import { Page } from '../../models/listingFlow';
+import { tokens } from '../../theme/tokens';
 
 interface CopyElementToPageDialogProps {
   open: boolean;
@@ -69,13 +70,13 @@ const CopyElementToPageDialog: React.FC<CopyElementToPageDialogProps> = ({
       PaperProps={{ sx: { minHeight: 350 } }}
     >
       <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-        <FileCopyIcon sx={{ color: '#009F64' }} />
+        <FileCopyIcon sx={{ color: tokens.brand.green }} />
         Element auf andere Seite kopieren
       </DialogTitle>
 
       <DialogContent dividers>
         {/* Element-Info */}
-        <Box sx={{ mb: 2, p: 1.5, bgcolor: '#F8FAFC', borderRadius: 1, border: '1px solid #E0E0E0' }}>
+        <Box sx={{ mb: 2, p: 1.5, bgcolor: tokens.surface.appBg, borderRadius: 1, border: `1px solid ${tokens.neutral.border}` }}>
           <Typography variant="subtitle2" color="text.secondary">
             Element: <strong>{elementTitle}</strong>
           </Typography>
@@ -86,7 +87,7 @@ const CopyElementToPageDialog: React.FC<CopyElementToPageDialogProps> = ({
           Zielseite auswählen:
         </Typography>
 
-        <List dense sx={{ maxHeight: 250, overflow: 'auto', border: '1px solid #E0E0E0', borderRadius: 1, mb: 2 }}>
+        <List dense sx={{ maxHeight: 250, overflow: 'auto', border: `1px solid ${tokens.neutral.border}`, borderRadius: 1, mb: 2 }}>
           {pages.map((page) => {
             const isSelected = selectedPageId === page.id;
             const isCurrent = page.id === currentPageId;
@@ -112,8 +113,8 @@ const CopyElementToPageDialog: React.FC<CopyElementToPageDialogProps> = ({
                       disableRipple
                       size="small"
                       sx={{
-                        color: '#009F64',
-                        '&.Mui-checked': { color: '#009F64' },
+                        color: tokens.brand.green,
+                        '&.Mui-checked': { color: tokens.brand.green },
                       }}
                     />
                   </ListItemIcon>
@@ -126,7 +127,7 @@ const CopyElementToPageDialog: React.FC<CopyElementToPageDialogProps> = ({
                             label="aktuelle Seite"
                             size="small"
                             variant="outlined"
-                            sx={{ fontSize: '0.65rem', height: 18, color: '#666' }}
+                            sx={{ fontSize: '0.65rem', height: 18, color: tokens.neutral.muted }}
                           />
                         )}
                       </Box>
@@ -163,12 +164,12 @@ const CopyElementToPageDialog: React.FC<CopyElementToPageDialogProps> = ({
           >
             <FormControlLabel
               value="top"
-              control={<Radio size="small" sx={{ color: '#009F64', '&.Mui-checked': { color: '#009F64' } }} />}
+              control={<Radio size="small" sx={{ color: tokens.brand.green, '&.Mui-checked': { color: tokens.brand.green } }} />}
               label={<Typography variant="body2">Am Anfang der Seite</Typography>}
             />
             <FormControlLabel
               value="bottom"
-              control={<Radio size="small" sx={{ color: '#009F64', '&.Mui-checked': { color: '#009F64' } }} />}
+              control={<Radio size="small" sx={{ color: tokens.brand.green, '&.Mui-checked': { color: tokens.brand.green } }} />}
               label={<Typography variant="body2">Am Ende der Seite</Typography>}
             />
           </RadioGroup>
@@ -185,9 +186,9 @@ const CopyElementToPageDialog: React.FC<CopyElementToPageDialogProps> = ({
           disabled={!selectedPageId}
           startIcon={<FileCopyIcon />}
           sx={{
-            bgcolor: '#009F64',
-            '&:hover': { bgcolor: '#008755' },
-            '&.Mui-disabled': { bgcolor: '#E0E0E0' },
+            bgcolor: tokens.brand.green,
+            '&:hover': { bgcolor: tokens.brand.greenHoverAlt },
+            '&.Mui-disabled': { bgcolor: tokens.neutral.border },
           }}
         >
           Kopieren

--- a/src/components/HybridEditor/ElementContextView.tsx
+++ b/src/components/HybridEditor/ElementContextView.tsx
@@ -65,6 +65,7 @@ import { arePathsEqual } from '../../utils/pathUtils';
 import { isElementAllowedInParent, resolvePatternType } from '../../utils/nestingRules';
 import { getContainerType } from '../../context/EditorContext';
 import { logger } from '../../utils/logger';
+import { tokens } from '../../theme/tokens';
 
 const ContextViewContainer = styled(Box)`
   padding: 1rem;
@@ -74,13 +75,13 @@ const ContextViewContainer = styled(Box)`
 
 const ElementCard = styled(Card)<{ $isSelected: boolean }>`
   margin-bottom: 1rem;
-  border: 1px solid ${props => props.$isSelected ? '#009F64' : '#E0E0E0'};
+  border: 1px solid ${props => props.$isSelected ? tokens.brand.green : tokens.neutral.border};
   border-radius: 8px;
   transition: all 0.2s ease;
   position: relative;
 
   &:hover {
-    border-color: ${props => props.$isSelected ? '#009F64' : '#009F64'};
+    border-color: ${props => props.$isSelected ? tokens.brand.green : tokens.brand.green};
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   }
 `;
@@ -93,16 +94,16 @@ const ElementHeader = styled(Box)<ElementHeaderProps>`
   display: flex;
   align-items: center;
   padding: 0.5rem 1rem;
-  background-color: ${props => props.color || '#F8FAFC'};
+  background-color: ${props => props.color || tokens.surface.appBg};
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
-  border-bottom: 1px solid #E0E0E0;
+  border-bottom: 1px solid ${tokens.neutral.border};
 `;
 
 const ElementTitle = styled(Typography)`
   font-weight: 500;
   flex-grow: 1;
-  color: #2A2E3F;
+  color: ${tokens.text.primary};
 `;
 
 const ElementContent = styled(CardContent)`
@@ -112,7 +113,7 @@ const ElementContent = styled(CardContent)`
 const ElementActions = styled(CardActions)`
   padding: 0.5rem;
   justify-content: flex-end;
-  background-color: #F8FAFC;
+  background-color: ${tokens.surface.appBg};
 `;
 
 const EmptyState = styled(Box)`
@@ -121,21 +122,21 @@ const EmptyState = styled(Box)`
   align-items: center;
   justify-content: center;
   padding: 2rem;
-  border: 2px dashed #E0E0E0;
+  border: 2px dashed ${tokens.neutral.border};
   border-radius: 8px;
   margin-top: 1rem;
-  background-color: #F8FAFC;
+  background-color: ${tokens.surface.appBg};
   text-align: center;
 `;
 
 const AddElementButton = styled(Button)`
   margin-top: 1rem;
-  background-color: #43E77F;
-  color: #000000;
-  border: 1px solid #000000;
+  background-color: ${tokens.brand.greenBright};
+  color: ${tokens.neutral.black};
+  border: 1px solid ${tokens.neutral.black};
 
   &:hover {
-    background-color: #35D870;
+    background-color: ${tokens.brand.greenBrightStrong};
   }
 `;
 
@@ -218,7 +219,7 @@ const getElementColor = (elementType: string | undefined) => {
   } else if (elementType === 'ChipGroupUIElement') {
     return 'rgba(63, 81, 181, 0.05)';
   }
-  return '#F8FAFC';
+  return tokens.surface.appBg;
 };
 
 // Hilfsfunktion zum Ermitteln, ob ein Element Unterelemente haben kann
@@ -625,10 +626,10 @@ const DraggableElementCard: React.FC<{
           opacity: isDragging ? 0.4 : 1,
           cursor: isContainer && elementHasChildren ? 'pointer' : 'default',
           ...(isOver ? {
-            borderTop: '3px solid #009F64',
+            borderTop: `3px solid ${tokens.brand.green}`,
           } : {}),
           ...(isSelectionMode && isCardMultiSelected ? {
-            outline: '2px solid #1976d2',
+            outline: `2px solid ${tokens.accentBlue.main}`,
             outlineOffset: '1px',
             backgroundColor: 'rgba(25, 118, 210, 0.04)'
           } : {}),
@@ -877,19 +878,19 @@ const DraggableElementCard: React.FC<{
                 variant="contained"
                 sx={{
                   backgroundColor:
-                    containerType === 'group' ? '#009F64' :
-                    containerType === 'array' ? '#F05B29' :
-                    containerType === 'chipgroup' ? '#3F51B5' :
-                    containerType === 'custom' ? '#009F64' :
-                    containerType === 'subflow' ? '#009F64' :
-                    '#009F64',
-                  color: '#fff',
+                    containerType === 'group' ? tokens.brand.green :
+                    containerType === 'array' ? tokens.brand.orange :
+                    containerType === 'chipgroup' ? tokens.accentIndigo.main :
+                    containerType === 'custom' ? tokens.brand.green :
+                    containerType === 'subflow' ? tokens.brand.green :
+                    tokens.brand.green,
+                  color: tokens.surface.paper,
                   '&:hover': {
                     backgroundColor:
-                      containerType === 'group' ? '#008555' :
-                      containerType === 'array' ? '#D04E24' :
-                      containerType === 'chipgroup' ? '#303F9F' :
-                      '#008555',
+                      containerType === 'group' ? tokens.brand.greenPressed :
+                      containerType === 'array' ? tokens.brand.orangePressed :
+                      containerType === 'chipgroup' ? tokens.accentIndigo.dark :
+                      tokens.brand.greenPressed,
                   }
                 }}
               >
@@ -915,8 +916,8 @@ const DraggableElementCard: React.FC<{
                 color="warning"
                 variant="outlined"
                 sx={{
-                  borderColor: '#ED6C02',
-                  color: '#ED6C02',
+                  borderColor: tokens.status.warning,
+                  color: tokens.status.warning,
                 }}
               >
                 Gruppierung auflösen
@@ -1167,7 +1168,7 @@ const ElementContextView: React.FC<ElementContextViewProps> = ({
       {elements.length > 0 ? (
         <>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
-            <Typography variant="h6" color="#2A2E3F">
+            <Typography variant="h6" color={tokens.text.primary}>
               Elemente in dieser Ebene
             </Typography>
 
@@ -1180,11 +1181,11 @@ const ElementContextView: React.FC<ElementContextViewProps> = ({
                 setElementTypeDialogOpen(true);
               }}
               sx={{
-                bgcolor: '#43E77F',
-                color: '#000000',
-                border: '1px solid #000000',
+                bgcolor: tokens.brand.greenBright,
+                color: tokens.neutral.black,
+                border: `1px solid ${tokens.neutral.black}`,
                 '&:hover': {
-                  bgcolor: '#35D870',
+                  bgcolor: tokens.brand.greenBrightStrong,
                 }
               }}
             >

--- a/src/components/HybridEditor/ElementHierarchyTree.tsx
+++ b/src/components/HybridEditor/ElementHierarchyTree.tsx
@@ -39,13 +39,14 @@ import AttachFileIcon from '@mui/icons-material/AttachFile';
 import { PatternLibraryElement } from '../../models/listingFlow';
 import { arePathsEqual } from '../../utils/pathUtils';
 import { getSubElements, getContainerType } from '../../context/EditorContext'; // Importiere getSubElements und getContainerType
+import { tokens } from '../../theme/tokens';
 
 const LINE_COLOR = 'rgba(0, 0, 0, 0.23)'; // Farbe für die Verbindungslinien, ähnlich wie Divider
 
 const TreeItem = styled(ListItem)<{ depth: number; isSelected: boolean; isLastChild?: boolean; hasChildren?: boolean }>`
   padding-left: ${props => props.depth * 20 + 8}px; // Erhöhte Einrückung
   background-color: ${props => props.isSelected ? 'rgba(0, 159, 100, 0.1)' : 'transparent'};
-  border-left: ${props => props.isSelected ? '3px solid #009F64' : '3px solid transparent'};
+  border-left: ${props => props.isSelected ? `3px solid ${tokens.brand.green}` : '3px solid transparent'};
   position: relative; // Für Pseudoelemente
 
   // Vertikale Linie von oben zum aktuellen Element
@@ -105,7 +106,7 @@ const TreeItemText = styled(ListItemText)`
 
   .MuiListItemText-primary {
     font-size: 0.875rem;
-    color: #2A2E3F;
+    color: ${tokens.text.primary};
     font-weight: ${props => props.primary === 'true' ? 'bold' : 'normal'};
     white-space: nowrap;
     overflow: hidden;
@@ -229,10 +230,10 @@ const TreeNode: React.FC<{
 
   // Bestimme den Container-Typ des Elements
   const containerType = React.useMemo(() => getContainerType(element), [element]);
-  const containerColor = containerType === 'array' ? '#F05B29' :
-                         containerType === 'chipgroup' ? '#3F51B5' : '#009F64';
-  const containerColorDark = containerType === 'array' ? '#D04E24' :
-                             containerType === 'chipgroup' ? '#303F9F' : '#008555';
+  const containerColor = containerType === 'array' ? tokens.brand.orange :
+                         containerType === 'chipgroup' ? tokens.accentIndigo.main : tokens.brand.green;
+  const containerColorDark = containerType === 'array' ? tokens.brand.orangePressed :
+                             containerType === 'chipgroup' ? tokens.accentIndigo.dark : tokens.brand.greenPressed;
 
   // Bestimme, ob das Element eine Visibility Condition hat
   const hasVisibilityCondition = () => {
@@ -388,7 +389,7 @@ const TreeNode: React.FC<{
                 }}
                 sx={{
                   ml: 'auto',
-                  color: isCurrentContext ? '#fff' : containerColor,
+                  color: isCurrentContext ? tokens.surface.paper : containerColor,
                   ...(isCurrentContext ? {
                     bgcolor: containerColor,
                     '&:hover': { bgcolor: containerColorDark },

--- a/src/components/HybridEditor/EnhancedPropertyEditor.tsx
+++ b/src/components/HybridEditor/EnhancedPropertyEditor.tsx
@@ -24,27 +24,28 @@ import { VisibilityConditionEditor } from '../PropertyEditor/editors/VisibilityC
 import StructureNavigator from './StructureNavigator';
 import EnhancedElementEditorFactory from './EnhancedElementEditorFactory';
 import { getContainerType, useEditor } from '../../context/EditorContext';
+import { tokens } from '../../theme/tokens';
 
 const PropertyEditorContainer = styled(Paper)`
   width: 100%;
   height: 100%;
-  background-color: #F8FAFC;
+  background-color: ${tokens.surface.appBg};
   overflow-y: auto;
   display: flex;
   flex-direction: column;
   border-radius: 0;
-  border-left: 1px solid #E0E0E0;
+  border-left: 1px solid ${tokens.neutral.border};
 `;
 
 const EditorHeader = styled(Box)`
   padding: 1rem;
-  background-color: #F8FAFC;
-  border-bottom: 1px solid #E0E0E0;
+  background-color: ${tokens.surface.appBg};
+  border-bottom: 1px solid ${tokens.neutral.border};
 `;
 
 const EditorTitle = styled(Typography)`
   font-weight: 500;
-  color: #2A2E3F;
+  color: ${tokens.text.primary};
 `;
 
 const EditorContent = styled(Box)`
@@ -65,7 +66,7 @@ const Form = styled.form`
 const SectionTitle = styled(Typography)`
   font-weight: 500;
   margin-top: 1rem;
-  color: #009F64;
+  color: ${tokens.brand.green};
   padding-bottom: 0.5rem;
   border-bottom: 1px solid rgba(0, 159, 100, 0.1);
 `;
@@ -82,7 +83,7 @@ const NoElementSelected = styled(Box)`
   height: 100%;
   padding: 2rem;
   text-align: center;
-  color: #2A2E3F;
+  color: ${tokens.text.primary};
 `;
 
 interface EnhancedPropertyEditorProps {
@@ -308,7 +309,7 @@ const EnhancedPropertyEditor: React.FC<EnhancedPropertyEditorProps> = ({
         <Box
           sx={{
             p: 2,
-            backgroundColor: '#f5f5f5',
+            backgroundColor: tokens.surface.subtle,
             borderRadius: 1,
             fontFamily: 'monospace',
             fontSize: '0.875rem',
@@ -388,11 +389,11 @@ const EnhancedPropertyEditor: React.FC<EnhancedPropertyEditorProps> = ({
               variant="body2"
               sx={{
                 color:
-                  getContainerType(element) === 'group' ? '#009F64' :
-                  getContainerType(element) === 'array' ? '#F05B29' :
-                  getContainerType(element) === 'chipgroup' ? '#3F51B5' :
-                  getContainerType(element) === 'custom' ? '#009F64' :
-                  getContainerType(element) === 'subflow' ? '#009F64' :
+                  getContainerType(element) === 'group' ? tokens.brand.green :
+                  getContainerType(element) === 'array' ? tokens.brand.orange :
+                  getContainerType(element) === 'chipgroup' ? tokens.accentIndigo.main :
+                  getContainerType(element) === 'custom' ? tokens.brand.green :
+                  getContainerType(element) === 'subflow' ? tokens.brand.green :
                   'text.secondary'
               }}
             >

--- a/src/components/HybridEditor/ExportElementToFileDialog.tsx
+++ b/src/components/HybridEditor/ExportElementToFileDialog.tsx
@@ -30,6 +30,7 @@ import { ListingFlow, PatternLibraryElement } from '../../models/listingFlow';
 import { normalizeElementTypes } from '../../utils/normalizeUtils';
 import { deepCloneElement, findVisibilityFieldReferences } from '../../utils/deepCloneUtils';
 import { ensureUUIDs } from '../../utils/uuidUtils';
+import { tokens } from '../../theme/tokens';
 
 interface ExportElementToFileDialogProps {
   open: boolean;
@@ -169,7 +170,7 @@ const ExportElementToFileDialog: React.FC<ExportElementToFileDialogProps> = ({
       PaperProps={{ sx: { minHeight: 400 } }}
     >
       <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-        <IosShareIcon sx={{ color: '#1976D2' }} />
+        <IosShareIcon sx={{ color: tokens.accentBlue.main }} />
         Element in andere JSON-Datei exportieren
       </DialogTitle>
 
@@ -184,7 +185,7 @@ const ExportElementToFileDialog: React.FC<ExportElementToFileDialogProps> = ({
         />
 
         {/* Element-Info */}
-        <Box sx={{ mb: 2, p: 1.5, bgcolor: '#F8FAFC', borderRadius: 1, border: '1px solid #E0E0E0' }}>
+        <Box sx={{ mb: 2, p: 1.5, bgcolor: tokens.surface.appBg, borderRadius: 1, border: `1px solid ${tokens.neutral.border}` }}>
           <Typography variant="subtitle2" color="text.secondary">
             Element: <strong>{elementTitle}</strong>
           </Typography>
@@ -217,7 +218,7 @@ const ExportElementToFileDialog: React.FC<ExportElementToFileDialogProps> = ({
             variant="outlined"
             startIcon={<FolderOpenIcon />}
             onClick={handleFileSelect}
-            sx={{ borderColor: '#1976D2', color: '#1976D2' }}
+            sx={{ borderColor: tokens.accentBlue.main, color: tokens.accentBlue.main }}
           >
             {targetFlow ? 'Andere Zieldatei wählen' : 'Ziel-JSON-Datei auswählen'}
           </Button>
@@ -243,7 +244,7 @@ const ExportElementToFileDialog: React.FC<ExportElementToFileDialogProps> = ({
         {/* Zieldatei-Info + Seitenauswahl */}
         {targetFlow && (
           <>
-            <Box sx={{ mb: 2, p: 1.5, bgcolor: '#F0F4FF', borderRadius: 1, border: '1px solid #C8D6E5' }}>
+            <Box sx={{ mb: 2, p: 1.5, bgcolor: tokens.accentIndigo.bg, borderRadius: 1, border: `1px solid ${tokens.neutral.borderCool}` }}>
               <Typography variant="subtitle2" color="text.secondary">
                 Zieldatei: <strong>{targetFlow.name || targetFlow.id || targetFileName}</strong>
               </Typography>
@@ -257,7 +258,7 @@ const ExportElementToFileDialog: React.FC<ExportElementToFileDialogProps> = ({
               Zielseite auswählen:
             </Typography>
 
-            <List dense sx={{ maxHeight: 200, overflow: 'auto', border: '1px solid #E0E0E0', borderRadius: 1, mb: 2 }}>
+            <List dense sx={{ maxHeight: 200, overflow: 'auto', border: `1px solid ${tokens.neutral.border}`, borderRadius: 1, mb: 2 }}>
               {targetFlow.pages_edit.map((page) => {
                 const isSelected = selectedPageId === page.id;
                 const pageTitle = page.title?.de || page.short_title?.de || page.id;
@@ -282,8 +283,8 @@ const ExportElementToFileDialog: React.FC<ExportElementToFileDialogProps> = ({
                           disableRipple
                           size="small"
                           sx={{
-                            color: '#1976D2',
-                            '&.Mui-checked': { color: '#1976D2' },
+                            color: tokens.accentBlue.main,
+                            '&.Mui-checked': { color: tokens.accentBlue.main },
                           }}
                         />
                       </ListItemIcon>
@@ -321,12 +322,12 @@ const ExportElementToFileDialog: React.FC<ExportElementToFileDialogProps> = ({
               >
                 <FormControlLabel
                   value="top"
-                  control={<Radio size="small" sx={{ color: '#1976D2', '&.Mui-checked': { color: '#1976D2' } }} />}
+                  control={<Radio size="small" sx={{ color: tokens.accentBlue.main, '&.Mui-checked': { color: tokens.accentBlue.main } }} />}
                   label={<Typography variant="body2">Am Anfang der Seite</Typography>}
                 />
                 <FormControlLabel
                   value="bottom"
-                  control={<Radio size="small" sx={{ color: '#1976D2', '&.Mui-checked': { color: '#1976D2' } }} />}
+                  control={<Radio size="small" sx={{ color: tokens.accentBlue.main, '&.Mui-checked': { color: tokens.accentBlue.main } }} />}
                   label={<Typography variant="body2">Am Ende der Seite</Typography>}
                 />
               </RadioGroup>
@@ -364,9 +365,9 @@ const ExportElementToFileDialog: React.FC<ExportElementToFileDialogProps> = ({
           disabled={!selectedPageId || !targetFlow}
           startIcon={<IosShareIcon />}
           sx={{
-            bgcolor: '#1976D2',
-            '&:hover': { bgcolor: '#1565C0' },
-            '&.Mui-disabled': { bgcolor: '#E0E0E0' },
+            bgcolor: tokens.accentBlue.main,
+            '&:hover': { bgcolor: tokens.accentBlue.dark },
+            '&.Mui-disabled': { bgcolor: tokens.neutral.border },
           }}
         >
           Exportieren & Herunterladen

--- a/src/components/HybridEditor/HybridEditor.tsx
+++ b/src/components/HybridEditor/HybridEditor.tsx
@@ -24,6 +24,7 @@ import VisibilityLegend from './VisibilityLegend';
 import { logger } from '../../utils/logger';
 import FloatingActionBar from '../EditorArea/FloatingActionBar';
 import WrapInGroupDialog from '../EditorArea/WrapInGroupDialog';
+import { tokens } from '../../theme/tokens';
 import FolderIcon from '@mui/icons-material/Folder';
 import ViewArrayIcon from '@mui/icons-material/ViewArray';
 import ToggleOnIcon from '@mui/icons-material/ToggleOn';
@@ -47,8 +48,8 @@ const LeftColumn = styled.div`
   min-width: 220px;
   height: 100%;
   overflow-y: auto;
-  background-color: #F0F2F4;
-  border-right: 1px solid #E0E0E0;
+  background-color: ${tokens.surface.subtleAlt};
+  border-right: 1px solid ${tokens.neutral.border};
   display: flex;
   flex-direction: column;
 `;
@@ -59,7 +60,7 @@ const MiddleColumn = styled.div`
   height: 100%;
   overflow-y: auto;
   padding: 1rem;
-  background-color: #F8FAFC;
+  background-color: ${tokens.surface.appBg};
   display: flex;
   flex-direction: column;
 `;
@@ -69,15 +70,15 @@ const RightColumn = styled.div`
   min-width: 320px;
   height: 100%;
   overflow-y: auto;
-  background-color: #F8FAFC;
-  border-left: 1px solid #E0E0E0;
+  background-color: ${tokens.surface.appBg};
+  border-left: 1px solid ${tokens.neutral.border};
   padding: 1rem;
 `;
 
 const BreadcrumbContainer = styled(Box)`
   padding: 0.5rem 1rem;
-  background-color: #F8FAFC;
-  border-bottom: 1px solid #E0E0E0;
+  background-color: ${tokens.surface.appBg};
+  border-bottom: 1px solid ${tokens.neutral.border};
   display: flex;
   align-items: center;
 `;
@@ -482,7 +483,7 @@ const HybridEditor: React.FC<HybridEditorProps> = ({
     <EditorContainer>
       {/* Linke Spalte: Hierarchische Baumansicht */}
       <LeftColumn role="region" aria-label="Element-Hierarchie">
-        <Typography variant="subtitle1" sx={{ p: 2, fontWeight: 'bold', color: '#2A2E3F' }}>
+        <Typography variant="subtitle1" sx={{ p: 2, fontWeight: 'bold', color: tokens.text.primary }}>
           Element-Hierarchie
         </Typography>
         <Divider />
@@ -594,7 +595,7 @@ const HybridEditor: React.FC<HybridEditorProps> = ({
                   {item.label}
                   {item.containerType && item.containerType !== 'root' && (
                     <Tooltip title={`Container-Typ: ${item.containerType}`}>
-                      <Box component="span" sx={{ ml: 0.5, fontSize: '0.75rem', color: 'text.secondary', bgcolor: '#f0f0f0', px: 0.5, borderRadius: 1 }}>
+                      <Box component="span" sx={{ ml: 0.5, fontSize: '0.75rem', color: 'text.secondary', bgcolor: tokens.surface.subtleAlt2, px: 0.5, borderRadius: 1 }}>
                         {item.containerType}
                       </Box>
                     </Tooltip>
@@ -612,7 +613,7 @@ const HybridEditor: React.FC<HybridEditorProps> = ({
                   {item.label}
                   {item.containerType && item.containerType !== 'root' && (
                     <Tooltip title={`Container-Typ: ${item.containerType}`}>
-                      <Box component="span" sx={{ ml: 0.5, fontSize: '0.75rem', color: 'text.secondary', bgcolor: '#f0f0f0', px: 0.5, borderRadius: 1 }}>
+                      <Box component="span" sx={{ ml: 0.5, fontSize: '0.75rem', color: 'text.secondary', bgcolor: tokens.surface.subtleAlt2, px: 0.5, borderRadius: 1 }}>
                         {item.containerType}
                       </Box>
                     </Tooltip>

--- a/src/components/HybridEditor/StructureNavigator.tsx
+++ b/src/components/HybridEditor/StructureNavigator.tsx
@@ -17,6 +17,7 @@ import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import { PatternLibraryElement } from '../../models/listingFlow';
 import { getElementIcon } from './ElementContextView';
 import { getContainerType, getSubElements } from '../../context/EditorContext';
+import { tokens } from '../../theme/tokens';
 
 interface StructureNavigatorProps {
   element: PatternLibraryElement;
@@ -128,11 +129,11 @@ const StructureNavigator: React.FC<StructureNavigatorProps> = ({
                             <Box component="span" sx={{
                               ml: 1,
                               color:
-                                subElementContainerType === 'group' ? '#009F64' :
-                                subElementContainerType === 'array' ? '#F05B29' :
-                                subElementContainerType === 'chipgroup' ? '#3F51B5' :
-                                subElementContainerType === 'custom' ? '#009F64' :
-                                subElementContainerType === 'subflow' ? '#009F64' :
+                                subElementContainerType === 'group' ? tokens.brand.green :
+                                subElementContainerType === 'array' ? tokens.brand.orange :
+                                subElementContainerType === 'chipgroup' ? tokens.accentIndigo.main :
+                                subElementContainerType === 'custom' ? tokens.brand.green :
+                                subElementContainerType === 'subflow' ? tokens.brand.green :
                                 'inherit'
                             }}>
                               ({subElementContainerType})

--- a/src/components/HybridEditor/VisibilityConditionBuilder.tsx
+++ b/src/components/HybridEditor/VisibilityConditionBuilder.tsx
@@ -23,6 +23,7 @@ import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 
 import { useEditor } from '../../context/EditorContext';
+import { tokens } from '../../theme/tokens';
 
 const BuilderContainer = styled(Box)`
   margin-top: 1rem;
@@ -30,11 +31,11 @@ const BuilderContainer = styled(Box)`
 
 const ConditionCard = styled(Card)`
   margin-bottom: 1rem;
-  border: 1px solid #E0E0E0;
+  border: 1px solid ${tokens.neutral.border};
   border-radius: 8px;
 
   &:hover {
-    border-color: #009F64;
+    border-color: ${tokens.brand.green};
   }
 `;
 
@@ -56,12 +57,12 @@ const ValueField = styled(TextField)`
 
 const AddConditionButton = styled(Button)`
   margin-top: 1rem;
-  background-color: #43E77F;
-  color: #000000;
-  border: 1px solid #000000;
+  background-color: ${tokens.brand.greenBright};
+  color: ${tokens.neutral.black};
+  border: 1px solid ${tokens.neutral.black};
 
   &:hover {
-    background-color: #35D870;
+    background-color: ${tokens.brand.greenBrightStrong};
   }
 `;
 
@@ -73,9 +74,9 @@ const LogicOperatorChip = styled(Chip)`
 const PreviewContainer = styled(Box)`
   margin-top: 1rem;
   padding: 1rem;
-  background-color: #f5f5f5;
+  background-color: ${tokens.surface.subtle};
   border-radius: 8px;
-  border: 1px solid #E0E0E0;
+  border: 1px solid ${tokens.neutral.border};
 `;
 
 interface VisibilityConditionBuilderProps {

--- a/src/components/IconSelector/IconSelector.tsx
+++ b/src/components/IconSelector/IconSelector.tsx
@@ -17,6 +17,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import SearchIcon from '@mui/icons-material/Search';
 import Icon from '@mdi/react';
 import { getCategorizedIcons, getIconPath, getMdiIconNames } from '../../utils/mdiIcons';
+import { tokens } from '../../theme/tokens';
 
 // Kategorisierung der Icons basierend auf MDI-Icons
 const ICON_CATEGORIES = getCategorizedIcons();
@@ -223,10 +224,10 @@ const IconSelector: React.FC<IconSelectorProps> = ({
                     display: 'flex',
                     flexDirection: 'column',
                     borderRadius: 1,
-                    border: currentIcon === iconName ? '2px solid #1976d2' : '1px solid transparent',
+                    border: currentIcon === iconName ? `2px solid ${tokens.accentBlue.main}` : '1px solid transparent',
                     '&:hover': {
                       backgroundColor: 'rgba(25, 118, 210, 0.04)',
-                      border: '1px solid #1976d2'
+                      border: `1px solid ${tokens.accentBlue.main}`
                     }
                   }}
                 >

--- a/src/components/JsonPreview/JsonPreview.tsx
+++ b/src/components/JsonPreview/JsonPreview.tsx
@@ -2,6 +2,7 @@ import React, { Suspense, useMemo } from 'react';
 import styled from 'styled-components';
 import { ListingFlow } from '../../models/listingFlow';
 import { transformFlowForExport } from '../../utils/uuidUtils';
+import { tokens } from '../../theme/tokens';
 
 // Lazy loading für react-json-view
 const ReactJson = React.lazy(() => import('react-json-view'));
@@ -12,7 +13,7 @@ interface JsonPreviewProps {
 }
 
 const PreviewContainer = styled.div`
-  background: #1e1e1e;
+  background: ${tokens.surface.dark};
   padding: 1rem;
   border-radius: 4px;
   overflow: auto;
@@ -23,7 +24,7 @@ const PreviewContainer = styled.div`
 const LoadingContainer = styled.div`
   padding: 1rem;
   text-align: center;
-  color: #666;
+  color: ${tokens.neutral.muted};
 `;
 
 const JsonPreview: React.FC<JsonPreviewProps> = ({ data, onEdit }) => {

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -13,6 +13,7 @@ import {
   KeyboardOutlined as KeyboardIcon,
   SchoolOutlined as OnboardingIcon
 } from '@mui/icons-material';
+import { tokens } from '../../theme/tokens';
 
 interface NavigationProps {
   onNew: () => void;
@@ -32,7 +33,7 @@ interface NavigationProps {
 }
 
 const StyledAppBar = styled(AppBar)`
-  background-color: #2A2E3F;
+  background-color: ${tokens.text.primary};
   color: white;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 `;
@@ -81,9 +82,9 @@ const Navigation: React.FC<NavigationProps> = ({
               startIcon={<AddIcon />}
               onClick={onNew}
               sx={{
-                bgcolor: '#009F64',
+                bgcolor: tokens.brand.green,
                 color: 'white',
-                '&:hover': { bgcolor: '#008D58' }
+                '&:hover': { bgcolor: tokens.brand.greenHover }
               }}
             >
               Neu
@@ -95,9 +96,9 @@ const Navigation: React.FC<NavigationProps> = ({
               startIcon={<OpenIcon />}
               onClick={onOpen}
               sx={{
-                bgcolor: '#009F64',
+                bgcolor: tokens.brand.green,
                 color: 'white',
-                '&:hover': { bgcolor: '#008D58' }
+                '&:hover': { bgcolor: tokens.brand.greenHover }
               }}
             >
               Öffnen
@@ -109,9 +110,9 @@ const Navigation: React.FC<NavigationProps> = ({
               startIcon={<SaveIcon />}
               onClick={onSave}
               sx={{
-                bgcolor: '#009F64',
+                bgcolor: tokens.brand.green,
                 color: 'white',
-                '&:hover': { bgcolor: '#008D58' }
+                '&:hover': { bgcolor: tokens.brand.greenHover }
               }}
             >
               Speichern
@@ -123,9 +124,9 @@ const Navigation: React.FC<NavigationProps> = ({
               startIcon={<EditIcon />}
               onClick={onEditWorkflowName}
               sx={{
-                bgcolor: '#009F64',
+                bgcolor: tokens.brand.green,
                 color: 'white',
-                '&:hover': { bgcolor: '#008D58' },
+                '&:hover': { bgcolor: tokens.brand.greenHover },
                 fontWeight: 'bold'
               }}
             >
@@ -158,9 +159,9 @@ const Navigation: React.FC<NavigationProps> = ({
                 size="large"
                 aria-label="Erste Schritte anzeigen"
                 sx={{
-                  bgcolor: '#009F64',
+                  bgcolor: tokens.brand.green,
                   color: 'white',
-                  '&:hover': { bgcolor: '#008D58' }
+                  '&:hover': { bgcolor: tokens.brand.greenHover }
                 }}
               >
                 <OnboardingIcon />
@@ -174,9 +175,9 @@ const Navigation: React.FC<NavigationProps> = ({
                 size="large"
                 aria-label="Tastaturkürzel anzeigen"
                 sx={{
-                  bgcolor: '#009F64',
+                  bgcolor: tokens.brand.green,
                   color: 'white',
-                  '&:hover': { bgcolor: '#008D58' }
+                  '&:hover': { bgcolor: tokens.brand.greenHover }
                 }}
               >
                 <KeyboardIcon />
@@ -190,9 +191,9 @@ const Navigation: React.FC<NavigationProps> = ({
                   onClick={onOpenDocumentation}
                   size="large"
                   sx={{
-                    bgcolor: '#009F64',
+                    bgcolor: tokens.brand.green,
                     color: 'white',
-                    '&:hover': { bgcolor: '#008D58' }
+                    '&:hover': { bgcolor: tokens.brand.greenHover }
                   }}
                 >
                   <HelpIcon />
@@ -207,9 +208,9 @@ const Navigation: React.FC<NavigationProps> = ({
                 disabled={!canUndo}
                 size="large"
                 sx={{
-                  bgcolor: '#009F64',
+                  bgcolor: tokens.brand.green,
                   color: 'white',
-                  '&:hover': { bgcolor: '#008D58' },
+                  '&:hover': { bgcolor: tokens.brand.greenHover },
                   '&.Mui-disabled': { opacity: 0.4, color: 'rgba(255, 255, 255, 0.5)' }
                 }}
               >
@@ -224,9 +225,9 @@ const Navigation: React.FC<NavigationProps> = ({
                 disabled={!canRedo}
                 size="large"
                 sx={{
-                  bgcolor: '#009F64',
+                  bgcolor: tokens.brand.green,
                   color: 'white',
-                  '&:hover': { bgcolor: '#008D58' },
+                  '&:hover': { bgcolor: tokens.brand.greenHover },
                   '&.Mui-disabled': { opacity: 0.4, color: 'rgba(255, 255, 255, 0.5)' }
                 }}
               >

--- a/src/components/PageNavigator/EditPageDialog.tsx
+++ b/src/components/PageNavigator/EditPageDialog.tsx
@@ -38,6 +38,7 @@ import { useEditor } from '../../context/EditorContext';
 import VisibilityConditionBuilder from '../HybridEditor/VisibilityConditionBuilder';
 import { toBuilderFormat, fromBuilderFormat, BuilderCondition } from '../../utils/visibilityConverters';
 import { transformEditPageToViewPage } from '../../utils/viewModeTransformer';
+import { tokens } from '../../theme/tokens';
 
 interface EditPageDialogProps {
   open: boolean;
@@ -314,12 +315,12 @@ const EditPageDialog: React.FC<EditPageDialogProps> = ({
                 expandIcon={<ExpandMoreIcon />}
                 sx={{
                   backgroundColor: !!visibilityCondition
-                    ? '#e3f2fd'
-                    : (childElementsHaveVisibilityConditions ? '#fff8e1' : 'inherit'),
+                    ? tokens.accentBlue.bg
+                    : (childElementsHaveVisibilityConditions ? tokens.status.warningBg : 'inherit'),
                   '&:hover': {
                     backgroundColor: !!visibilityCondition
-                      ? '#bbdefb'
-                      : (childElementsHaveVisibilityConditions ? '#ffecb3' : '#f5f5f5')
+                      ? tokens.accentBlue.border
+                      : (childElementsHaveVisibilityConditions ? tokens.status.warningBorder : tokens.surface.subtle)
                   }
                 }}
               >
@@ -528,7 +529,7 @@ const EditPageDialog: React.FC<EditPageDialogProps> = ({
                 sx={{
                   width: 48,
                   height: 48,
-                  border: '1px solid #ddd',
+                  border: `1px solid ${tokens.neutral.border}`,
                   borderRadius: 1,
                   display: 'flex',
                   alignItems: 'center',

--- a/src/components/PageNavigator/ImportPagesDialog.tsx
+++ b/src/components/PageNavigator/ImportPagesDialog.tsx
@@ -25,6 +25,7 @@ import { ListingFlow, Page } from '../../models/listingFlow';
 import { normalizeElementTypes } from '../../utils/normalizeUtils';
 import { deepClonePagePair, findCorrespondingViewPage } from '../../utils/deepCloneUtils';
 import { ensureUUIDs } from '../../utils/uuidUtils';
+import { tokens } from '../../theme/tokens';
 
 interface ImportPagesDialogProps {
   open: boolean;
@@ -161,7 +162,7 @@ const ImportPagesDialog: React.FC<ImportPagesDialogProps> = ({
       PaperProps={{ sx: { minHeight: 400 } }}
     >
       <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-        <UploadFileIcon sx={{ color: '#009F64' }} />
+        <UploadFileIcon sx={{ color: tokens.brand.green }} />
         Seiten importieren
       </DialogTitle>
 
@@ -181,7 +182,7 @@ const ImportPagesDialog: React.FC<ImportPagesDialogProps> = ({
             variant="outlined"
             startIcon={<FolderOpenIcon />}
             onClick={handleFileSelect}
-            sx={{ borderColor: '#009F64', color: '#009F64' }}
+            sx={{ borderColor: tokens.brand.green, color: tokens.brand.green }}
           >
             {sourceFlow ? 'Andere Datei wählen' : 'JSON-Datei auswählen'}
           </Button>
@@ -207,7 +208,7 @@ const ImportPagesDialog: React.FC<ImportPagesDialogProps> = ({
         {/* Quelldatei-Info */}
         {sourceFlow && (
           <>
-            <Box sx={{ mb: 2, p: 1.5, bgcolor: '#F8FAFC', borderRadius: 1, border: '1px solid #E0E0E0' }}>
+            <Box sx={{ mb: 2, p: 1.5, bgcolor: tokens.surface.appBg, borderRadius: 1, border: `1px solid ${tokens.neutral.border}` }}>
               <Typography variant="subtitle2" color="text.secondary">
                 Quelldatei: <strong>{sourceFlow.name || sourceFlow.id || sourceFileName}</strong>
               </Typography>
@@ -226,14 +227,14 @@ const ImportPagesDialog: React.FC<ImportPagesDialogProps> = ({
               <Button
                 size="small"
                 onClick={handleToggleAll}
-                sx={{ color: '#009F64' }}
+                sx={{ color: tokens.brand.green }}
               >
                 {allSelected ? 'Auswahl aufheben' : 'Alle auswählen'}
               </Button>
             </Box>
 
             {/* Seitenliste */}
-            <List dense sx={{ maxHeight: 300, overflow: 'auto', border: '1px solid #E0E0E0', borderRadius: 1 }}>
+            <List dense sx={{ maxHeight: 300, overflow: 'auto', border: `1px solid ${tokens.neutral.border}`, borderRadius: 1 }}>
               {sourceFlow.pages_edit.map((page) => {
                 const isSelected = selectedPageIds.includes(page.id);
                 const pageTitle = page.title?.de || page.short_title?.de || page.id;
@@ -256,8 +257,8 @@ const ImportPagesDialog: React.FC<ImportPagesDialogProps> = ({
                           tabIndex={-1}
                           disableRipple
                           sx={{
-                            color: '#009F64',
-                            '&.Mui-checked': { color: '#009F64' },
+                            color: tokens.brand.green,
+                            '&.Mui-checked': { color: tokens.brand.green },
                           }}
                         />
                       </ListItemIcon>
@@ -313,9 +314,9 @@ const ImportPagesDialog: React.FC<ImportPagesDialogProps> = ({
           onClick={handleImport}
           disabled={selectedPageIds.length === 0}
           sx={{
-            bgcolor: '#009F64',
-            '&:hover': { bgcolor: '#008755' },
-            '&.Mui-disabled': { bgcolor: '#E0E0E0' },
+            bgcolor: tokens.brand.green,
+            '&:hover': { bgcolor: tokens.brand.greenHoverAlt },
+            '&.Mui-disabled': { bgcolor: tokens.neutral.border },
           }}
         >
           {selectedPageIds.length > 0

--- a/src/components/PageNavigator/PageNavigator.tsx
+++ b/src/components/PageNavigator/PageNavigator.tsx
@@ -27,6 +27,7 @@ import { evaluateVisibilityCondition } from '../../utils/visibilityUtils';
 import PageTab from './PageTab';
 import EditPageDialog from './EditPageDialog';
 import ImportPagesDialog from './ImportPagesDialog';
+import { tokens } from '../../theme/tokens';
 
 interface PageNavigatorProps {
   pages: Page[];
@@ -169,7 +170,7 @@ const PageNavigator: React.FC<PageNavigatorProps> = ({ pages, selectedPageId }) 
   }
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', borderBottom: 1, borderColor: 'divider', bgcolor: '#F0F2F4', gap: 1, px: 1 }}>
+    <Box sx={{ display: 'flex', alignItems: 'center', borderBottom: 1, borderColor: 'divider', bgcolor: tokens.surface.subtleAlt, gap: 1, px: 1 }}>
       <Tabs
         value={
           selectedPageId && visiblePages.some(p => p.id === selectedPageId)
@@ -184,15 +185,15 @@ const PageNavigator: React.FC<PageNavigatorProps> = ({ pages, selectedPageId }) 
           flexGrow: 1,
           minWidth: 0, // Erlaubt Schrumpfen unter Flex-Kontext
           '& .MuiTabs-indicator': {
-            backgroundColor: '#009F64',
+            backgroundColor: tokens.brand.green,
           },
           '& .MuiTab-root': {
-            color: '#000000 !important',
+            color: `${tokens.neutral.black} !important`,
             fontWeight: 500,
             maxWidth: 180, // Verhindert extrem breite Tabs
             minWidth: 100,
             '&.Mui-selected': {
-              color: '#009F64 !important',
+              color: `${tokens.brand.green} !important`,
             }
           }
         }}
@@ -219,11 +220,11 @@ const PageNavigator: React.FC<PageNavigatorProps> = ({ pages, selectedPageId }) 
           onClick={handleAddPage}
           sx={{
             flexShrink: 0,
-            color: '#000000',
-            bgcolor: '#43E77F',
-            border: '1px solid #000000',
+            color: tokens.neutral.black,
+            bgcolor: tokens.brand.greenBright,
+            border: `1px solid ${tokens.neutral.black}`,
             '&:hover': {
-              bgcolor: '#35D870',
+              bgcolor: tokens.brand.greenBrightStrong,
             }
           }}
         >
@@ -236,11 +237,11 @@ const PageNavigator: React.FC<PageNavigatorProps> = ({ pages, selectedPageId }) 
           onClick={() => setImportDialogOpen(true)}
           sx={{
             flexShrink: 0,
-            color: '#000000',
-            bgcolor: '#81D4FA',
-            border: '1px solid #000000',
+            color: tokens.neutral.black,
+            bgcolor: tokens.accentBlue.lightSoft,
+            border: `1px solid ${tokens.neutral.black}`,
             '&:hover': {
-              bgcolor: '#4FC3F7',
+              bgcolor: tokens.accentBlue.light,
             }
           }}
         >

--- a/src/components/PageNavigator/PageTab.tsx
+++ b/src/components/PageNavigator/PageTab.tsx
@@ -5,6 +5,7 @@ import { Delete as DeleteIcon, Edit as EditIcon, Visibility as VisibilityIcon, A
 import Icon from '@mdi/react';
 import { getIconPath } from '../../utils/mdiIcons';
 import { Page } from '../../models/listingFlow';
+import { tokens } from '../../theme/tokens';
 
 // Konstanten für DnD
 export const ItemTypes = {
@@ -143,7 +144,7 @@ const PageTab: React.FC<PageTabProps> = ({
     // Prüfen, ob es sich um ein MDI-Icon handelt
     if (page.icon.startsWith('mdi')) {
       const iconPath = getIconPath(page.icon);
-      return iconPath ? <Icon path={iconPath} size={0.8} color="#000000" /> : null;
+      return iconPath ? <Icon path={iconPath} size={0.8} color={tokens.neutral.black} /> : null;
     }
 
     // Fallback für alte Material UI Icons (sollte nicht mehr vorkommen)
@@ -168,10 +169,10 @@ const PageTab: React.FC<PageTabProps> = ({
       <Tab
         value={page.id}
         label={
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, color: '#000000', maxWidth: '100%' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, color: tokens.neutral.black, maxWidth: '100%' }}>
             {renderIcon()}
-            <span style={{ 
-              color: '#000000', 
+            <span style={{
+              color: tokens.neutral.black,
               fontWeight: 500,
               whiteSpace: 'nowrap',
               overflow: 'hidden',
@@ -210,7 +211,7 @@ const PageTab: React.FC<PageTabProps> = ({
         }
         sx={{
           cursor: 'move',
-          color: '#000000',
+          color: tokens.neutral.black,
           '&:hover .page-menu-icon': {
             opacity: 1,
           },
@@ -236,12 +237,12 @@ const PageTab: React.FC<PageTabProps> = ({
                   borderRadius: '50%',
                   opacity: 0,
                   transition: 'opacity 0.2s',
-                  color: '#000000',
+                  color: tokens.neutral.black,
                   minWidth: 28,
                   minHeight: 28,
                   '&:hover': {
                     opacity: 1,
-                    color: '#009F64',
+                    color: tokens.brand.green,
                     backgroundColor: 'rgba(0, 0, 0, 0.04)',
                   }
                 }}
@@ -271,13 +272,13 @@ const PageTab: React.FC<PageTabProps> = ({
       >
         <MenuItem onClick={handleEdit}>
           <ListItemIcon>
-            <EditIcon fontSize="small" sx={{ color: '#009F64' }} />
+            <EditIcon fontSize="small" sx={{ color: tokens.brand.green }} />
           </ListItemIcon>
           <ListItemText>Seite bearbeiten</ListItemText>
         </MenuItem>
         <MenuItem onClick={handleDelete}>
           <ListItemIcon>
-            <DeleteIcon fontSize="small" sx={{ color: '#F05B29' }} />
+            <DeleteIcon fontSize="small" sx={{ color: tokens.brand.orange }} />
           </ListItemIcon>
           <ListItemText>Seite löschen</ListItemText>
         </MenuItem>

--- a/src/components/PropertyEditor/PropertyEditor.tsx
+++ b/src/components/PropertyEditor/PropertyEditor.tsx
@@ -58,17 +58,18 @@ import ChipGroupEditor from './editors/ChipGroupEditor';
 import SubflowNavigator from './common/SubflowNavigator';
 import { TranslatableField } from './common/TranslatableField';
 import IconField from './common/IconField';
+import { tokens } from '../../theme/tokens';
 
 const PropertyEditorContainer = styled(Paper)`
   width: 100%;
   height: 100%;
   padding: 1rem;
-  background-color: #F8FAFC;
+  background-color: ${tokens.surface.appBg};
   overflow-y: auto;
   display: flex;
   flex-direction: column;
   border-radius: 0;
-  border-left: 1px solid #E0E0E0;
+  border-left: 1px solid ${tokens.neutral.border};
 `;
 
 const Form = styled.form`
@@ -80,7 +81,7 @@ const Form = styled.form`
 const SectionTitle = styled(Typography)`
   font-weight: 500;
   margin-top: 1rem;
-  color: #009F64;
+  color: ${tokens.brand.green};
   padding-bottom: 0.5rem;
   border-bottom: 1px solid rgba(0, 159, 100, 0.1);
 `;
@@ -1276,9 +1277,9 @@ const PropertyEditor: React.FC<PropertyEditorProps> = ({ element, onUpdate }) =>
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
           sx={{
-            backgroundColor: !!visibilityCondition ? '#e3f2fd' : 'inherit',
+            backgroundColor: !!visibilityCondition ? tokens.accentBlue.bg : 'inherit',
             '&:hover': {
-              backgroundColor: !!visibilityCondition ? '#bbdefb' : '#f5f5f5'
+              backgroundColor: !!visibilityCondition ? tokens.accentBlue.border : tokens.surface.subtle
             }
           }}
         >
@@ -2251,7 +2252,7 @@ const PropertyEditor: React.FC<PropertyEditorProps> = ({ element, onUpdate }) =>
   if (!element) {
     return (
       <PropertyEditorContainer>
-        <Typography variant="subtitle1" sx={{ padding: 2, textAlign: 'center', color: '#666' }}>
+        <Typography variant="subtitle1" sx={{ padding: 2, textAlign: 'center', color: tokens.neutral.muted }}>
           Kein Element ausgewählt
         </Typography>
       </PropertyEditorContainer>
@@ -2267,9 +2268,9 @@ const PropertyEditor: React.FC<PropertyEditorProps> = ({ element, onUpdate }) =>
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
           sx={{
-            backgroundColor: !!visibilityCondition ? '#e3f2fd' : 'inherit',
+            backgroundColor: !!visibilityCondition ? tokens.accentBlue.bg : 'inherit',
             '&:hover': {
-              backgroundColor: !!visibilityCondition ? '#bbdefb' : '#f5f5f5'
+              backgroundColor: !!visibilityCondition ? tokens.accentBlue.border : tokens.surface.subtle
             }
           }}
         >
@@ -3053,7 +3054,7 @@ const PropertyEditor: React.FC<PropertyEditorProps> = ({ element, onUpdate }) =>
               <Typography variant="subtitle2" gutterBottom>
                 Vorschau:
               </Typography>
-              <Paper sx={{ p: 2, bgcolor: '#f5f5f5', borderRadius: 1 }}>
+              <Paper sx={{ p: 2, bgcolor: tokens.surface.subtle, borderRadius: 1 }}>
                 {textElement.type === 'HEADING' ? (
                   <Typography variant="h5" gutterBottom>
                     {textElement.text?.de || 'Überschrift'}
@@ -3211,7 +3212,7 @@ const PropertyEditor: React.FC<PropertyEditorProps> = ({ element, onUpdate }) =>
             <Typography variant="subtitle2" gutterBottom>Spalten</Typography>
 
             {columns.map((col, idx) => (
-              <Box key={idx} sx={{ mb: 2, p: 1.5, border: '1px solid #e0e0e0', borderRadius: 1 }}>
+              <Box key={idx} sx={{ mb: 2, p: 1.5, border: `1px solid ${tokens.neutral.border}`, borderRadius: 1 }}>
                 <Typography variant="caption" color="text.secondary">Spalte {idx + 1}</Typography>
                 <TextField
                   label="Kopfzeile (Deutsch)"

--- a/src/components/PropertyEditor/RefactoredPropertyEditor.tsx
+++ b/src/components/PropertyEditor/RefactoredPropertyEditor.tsx
@@ -4,12 +4,13 @@ import { Paper, Typography, Box } from '@mui/material';
 import { PatternLibraryElement } from '../../models/listingFlow';
 import { CommonPropertiesEditor } from './CommonPropertiesEditor';
 import { ElementEditorFactory } from './ElementEditorFactory';
+import { tokens } from '../../theme/tokens';
 
 const PropertyEditorContainer = styled(Paper)`
   width: 100%;
   height: 100%;
   padding: 1rem;
-  background-color: #f5f5f5;
+  background-color: ${tokens.surface.subtle};
   overflow-y: auto;
   display: flex;
   flex-direction: column;
@@ -33,7 +34,7 @@ export const RefactoredPropertyEditor: React.FC<PropertyEditorProps> = ({ elemen
   if (!element) {
     return (
       <PropertyEditorContainer>
-        <Typography variant="subtitle1" sx={{ padding: 2, textAlign: 'center', color: '#666' }}>
+        <Typography variant="subtitle1" sx={{ padding: 2, textAlign: 'center', color: tokens.neutral.muted }}>
           Kein Element ausgewählt
         </Typography>
       </PropertyEditorContainer>

--- a/src/components/PropertyEditor/common/ElementPreview.tsx
+++ b/src/components/PropertyEditor/common/ElementPreview.tsx
@@ -17,6 +17,7 @@ import PhoneAndroidIcon from '@mui/icons-material/PhoneAndroid';
 import DesktopWindowsIcon from '@mui/icons-material/DesktopWindows';
 import TabletIcon from '@mui/icons-material/Tablet';
 import { useUserPreferences } from '../../../context/UserPreferencesContext';
+import { tokens } from '../../../theme/tokens';
 
 interface ElementPreviewProps {
   title?: string;
@@ -153,7 +154,7 @@ export const ElementPreview: React.FC<ElementPreviewProps> = ({
               maxWidth: '100%',
               mx: 'auto',
               p: 2,
-              backgroundColor: '#fff',
+              backgroundColor: tokens.surface.paper,
               border: '1px dashed rgba(0, 0, 0, 0.12)',
               borderRadius: '4px',
               ...(previewMode === 'mobile' && {
@@ -170,7 +171,7 @@ export const ElementPreview: React.FC<ElementPreviewProps> = ({
                   transform: 'translateX(-50%)',
                   width: '40%',
                   height: '12px',
-                  backgroundColor: '#111',
+                  backgroundColor: tokens.neutral.nearBlack,
                   borderBottomLeftRadius: '8px',
                   borderBottomRightRadius: '8px',
                 }

--- a/src/components/PropertyEditor/editors/SingleSelectionElementEditor.tsx
+++ b/src/components/PropertyEditor/editors/SingleSelectionElementEditor.tsx
@@ -19,6 +19,7 @@ import AddIcon from '@mui/icons-material/Add';
 import { SingleSelectionUIElement, StringUIElement } from '../../../models/uiElements';
 import { v4 as uuidv4 } from 'uuid';
 import IconField from '../common/IconField';
+import { tokens } from '../../../theme/tokens';
 
 interface SingleSelectionElementEditorProps {
   element: SingleSelectionUIElement;
@@ -188,7 +189,7 @@ export const SingleSelectionElementEditor: React.FC<SingleSelectionElementEditor
       <Typography variant="subtitle2" gutterBottom>Optionen</Typography>
 
       {element.options?.map((option, index) => (
-        <Box key={index} sx={{ mb: 2, p: 2, border: '1px solid #e0e0e0', borderRadius: 1 }}>
+        <Box key={index} sx={{ mb: 2, p: 2, border: `1px solid ${tokens.neutral.border}`, borderRadius: 1 }}>
           <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 1 }}>
             <Box sx={{ width: '25%' }}>
               <TextField

--- a/src/components/PropertyEditor/editors/VisibilityConditionEditor.tsx
+++ b/src/components/PropertyEditor/editors/VisibilityConditionEditor.tsx
@@ -30,6 +30,7 @@ import {
   RelationalContextOperator
 } from '../../../models/listingFlow';
 import { useFieldValues } from '../../../context/FieldValuesContext';
+import { tokens } from '../../../theme/tokens';
 
 interface VisibilityConditionEditorProps {
   visibilityCondition: VisibilityCondition | undefined;
@@ -569,9 +570,9 @@ export const VisibilityConditionEditor: React.FC<VisibilityConditionEditorProps>
           <AccordionSummary
             expandIcon={<ExpandMoreIcon />}
             sx={{
-              backgroundColor: !!visibilityCondition ? '#e3f2fd' : 'inherit',
+              backgroundColor: !!visibilityCondition ? tokens.accentBlue.bg : 'inherit',
               '&:hover': {
-                backgroundColor: !!visibilityCondition ? '#bbdefb' : '#f5f5f5'
+                backgroundColor: !!visibilityCondition ? tokens.accentBlue.border : tokens.surface.subtle
               }
             }}
           >

--- a/src/components/common/ValidationStatus.tsx
+++ b/src/components/common/ValidationStatus.tsx
@@ -7,6 +7,7 @@ import { useEditor } from '../../context/EditorContext';
 import { useSchema } from '../../context/SchemaContext';
 import DialogBase from './DialogBase';
 import ValidationHelper, { ValidationMessage } from '../PropertyEditor/common/ValidationHelper';
+import { tokens } from '../../theme/tokens';
 
 /**
  * Wandelt AJV-Fehler in lesbare Validierungsmeldungen um. Filtert das if/then-Wrapper-
@@ -59,7 +60,7 @@ const ValidationStatus: React.FC = () => {
         icon={<CheckCircleOutlineIcon />}
         label="Gültig"
         aria-label="Flow ist schema-gültig"
-        sx={{ color: '#fff', borderColor: 'rgba(255,255,255,0.5)', '& .MuiChip-icon': { color: '#7CFFB2' } }}
+        sx={{ color: tokens.surface.paper, borderColor: 'rgba(255,255,255,0.5)', '& .MuiChip-icon': { color: tokens.brand.greenBrightSoft } }}
       />
     );
   }

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -1,0 +1,86 @@
+/**
+ * Zentrale Design-Tokens (Single Source of Truth für Farben).
+ *
+ * Alle Komponenten — egal ob via MUI-`sx`, styled-components oder inline-Style —
+ * referenzieren Farben ausschließlich über dieses Modul, nie über hardcodierte
+ * Hex-Werte. Das MUI-Theme (siehe `src/App.tsx`) wird ebenfalls aus diesen Tokens
+ * gebaut, sodass Theme-Palette und freie Styles garantiert konsistent bleiben.
+ *
+ * Werte sind 1:1 aus dem vorherigen, über die Komponenten verstreuten Bestand
+ * übernommen (reine Zentralisierung, keine visuelle Änderung). Künftige
+ * Konsolidierung fast-identischer Schattierungen kann hier zentral erfolgen.
+ */
+export const tokens = {
+  /** Corporate Branding — Grün-Ramp + Sekundär-Orange. */
+  brand: {
+    green: '#009F64',          // Primärgrün (palette.primary.main)
+    greenLight: '#4CC695',     // palette.primary.light
+    greenDark: '#005D3A',      // palette.primary.dark
+    greenHover: '#008D58',     // dunkler Hover des Primärgrüns
+    greenHoverAlt: '#008755',  // Hover-Variante
+    greenPressed: '#008555',   // Pressed/aktiv
+    greenDeep: '#007A4D',      // tiefer Akzent
+    greenBright: '#43E77F',    // helles Akzentgrün (Gradient/Highlight)
+    greenBrightStrong: '#35D870',
+    greenBrightSoft: '#7CFFB2',
+    orange: '#F05B29',         // Sekundär/Fehler (palette.secondary.main)
+    orangeDark: '#D04010',     // palette.secondary.dark
+    orangeLight: '#F78057',    // palette.secondary.light
+    orangePressed: '#D04E24',
+  },
+
+  /** Text-Farben. */
+  text: {
+    primary: '#2A2E3F',        // Überschriften (palette.text.primary)
+    secondary: '#343951',      // Fließtext (palette.text.secondary)
+  },
+
+  /** Flächen/Hintergründe. */
+  surface: {
+    appBg: '#F8FAFC',          // App-Hintergrund (palette.background.default)
+    paper: '#FFFFFF',          // Karten/Dialoge (palette.background.paper)
+    subtle: '#F5F5F5',         // leicht abgesetzte Fläche
+    subtleAlt: '#F0F2F4',
+    subtleAlt2: '#F0F0F0',
+    dark: '#1E1E1E',           // dunkle Fläche (z. B. Code)
+  },
+
+  /** Neutrale Töne — Rahmen, Icons, Schwarz. */
+  neutral: {
+    border: '#E0E0E0',         // Standard-Rahmen (palette.grey[300])
+    borderStrong: '#BDBDBD',   // palette.grey[400]
+    icon: '#848BA5',           // Icon-/Sekundärgrau (palette.grey[500])
+    borderCool: '#C8D6E5',     // bläulicher Rahmen
+    muted: '#666666',          // gedämpftes Grau (Hinweistexte)
+    nearBlack: '#111111',
+    black: '#000000',
+  },
+
+  /** Akzent-Blau (Info-/Hinweis-Flächen). */
+  accentBlue: {
+    main: '#1976D2',
+    dark: '#1565C0',
+    light: '#4FC3F7',
+    lightSoft: '#81D4FA',
+    bg: '#E3F2FD',
+    border: '#BBDEFB',
+  },
+
+  /** Akzent-Indigo. */
+  accentIndigo: {
+    main: '#3F51B5',
+    dark: '#303F9F',
+    bg: '#F0F4FF',
+  },
+
+  /** Status-Flächen (Warnung/Fehler) — eigenständig neben den Brand-Tönen. */
+  status: {
+    warning: '#ED6C02',
+    warningBg: '#FFF8E1',
+    warningBorder: '#FFECB3',
+    errorBg: '#FFF8F8',
+    errorBorder: '#FFCDD2',
+  },
+} as const;
+
+export default tokens;


### PR DESCRIPTION
Farben werden nicht mehr verstreut hardcodiert, sondern zentral in einem Token-Modul gepflegt.

## Kernlogik
- Neues `src/theme/tokens.ts` als Single Source of Truth für alle Farben (Brand-Greens/Orange, Text, Surface, Neutral, Accent-Blau/Indigo, Status).
- MUI-Theme in `App.tsx` (Palette + Typography) wird aus den Tokens gebaut → Theme und freie Styles können nicht mehr auseinanderlaufen.
- Sämtliche hardcodierten Hex-Farben in `src/components` auf Tokens umgestellt: styled-components via `${tokens.…}`-Interpolation, `sx`/inline als JS-Ausdruck.
- Werte 1:1 übernommen — reine Zentralisierung, **keine sichtbare Änderung** (fast-identische Grün-Schattierungen bewusst als eigene Tokens erhalten; Konsolidierung kann später zentral erfolgen).
- Akzeptanzkriterium erfüllt: kein rohes Hex-Literal mehr in TS/TSX (einzige Ausnahme: eine auskommentierte Zeile).

## Scope / Folgeschritte
- F2 fokussiert auf **Farben** (der konkrete, explizit genannte Teil von „F2 — Theme-Tokens").
- Spacing/Font-Sizes sind über MUI-Theme-Defaults bereits teils abgedeckt → kleiner Folgeschritt.
- `rgba(...)`-Werte mit Brand-Grün (z. B. `rgba(0,159,100,…)`) künftig über einen Alpha-Helfer aus Tokens ableiten.

## Test
1. `npm run build` → erfolgreich, keine TS-Fehler.
2. `npm test` → grün (118 passed).
3. App starten (`npm start`): Farben/Branding unverändert gegenüber `main` (Buttons grün, Sekundär orange, Hierarchie-Farbcodierung, Dialoge).

## Labels
Refactoring

🤖 https://claude.ai/code/session_01D2Pc4cAexeqUFrM1YonaJL

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2Pc4cAexeqUFrM1YonaJL)_